### PR TITLE
Adds `FlakyTheoryAttribute` and discovery

### DIFF
--- a/src/FlakyTest.XUnit/Attributes/FlakyFactAttribute.cs
+++ b/src/FlakyTest.XUnit/Attributes/FlakyFactAttribute.cs
@@ -37,10 +37,10 @@ public class FlakyFactAttribute : FactAttribute, IFlakyAttribute
         FlakyExplanation = flakyExplanation;
         RetriesBeforeFail = retriesBeforeFail;
     }
-    
+
     /// <inheritdoc />
     public string FlakyExplanation { get; }
-    
+
     /// <inheritdoc />
     public int RetriesBeforeFail { get; }
 }

--- a/src/FlakyTest.XUnit/Attributes/FlakyTheoryAttribute.cs
+++ b/src/FlakyTest.XUnit/Attributes/FlakyTheoryAttribute.cs
@@ -45,7 +45,7 @@ public class FlakyTheoryAttribute : TheoryAttribute, IFlakyAttribute
 
     /// <inheritdoc />
     public string FlakyExplanation { get; }
-    
+
     /// <inheritdoc />
     public int RetriesBeforeFail { get; }
 }

--- a/src/FlakyTest.XUnit/Attributes/FlakyTheoryAttribute.cs
+++ b/src/FlakyTest.XUnit/Attributes/FlakyTheoryAttribute.cs
@@ -11,7 +11,7 @@ namespace FlakyTest.XUnit.Attributes;
 /// Use of this attribute indicates a flaky test.
 /// </para>
 /// <para>
-/// This attribute should be used sparingly, but it can be used to mark a <see cref="FactAttribute"/> test as "flaky",
+/// This attribute should be used sparingly, but it can be used to mark a <see cref="TheoryAttribute"/> test as "flaky",
 /// which will cause the test runner to attempt to run the test until either:
 /// <list type="bullet">
 /// <item>The test passes</item>
@@ -20,16 +20,21 @@ namespace FlakyTest.XUnit.Attributes;
 /// If the test fails up to the maximum retries, it reports as failure.
 /// </para>
 /// </summary>
-[XunitTestCaseDiscoverer("FlakyTest.XUnit.Services.FlakyFactDiscoverer", "FlakyTest.XUnit")]
+[XunitTestCaseDiscoverer("FlakyTest.XUnit.Services.FlakyTheoryDiscoverer", "FlakyTest.XUnit")]
 [AttributeUsage(AttributeTargets.Method)]
-public class FlakyFactAttribute : FactAttribute, IFlakyAttribute
+public class FlakyTheoryAttribute : TheoryAttribute, IFlakyAttribute
 {
+    /// <summary>
+    /// The default number of retries before failing a test case.
+    /// </summary>
+    public const int DefaultRetriesBeforeFail = 5;
+
     /// <summary>
     /// Constructor
     /// </summary>
     /// <param name="flakyExplanation">The explanation to why the test is being marked flaky.</param>
     /// <param name="retriesBeforeFail">The number of retries prior to marking a test as failed.</param>
-    public FlakyFactAttribute(string flakyExplanation, int retriesBeforeFail = IFlakyAttribute.DefaultRetriesBeforeFail)
+    public FlakyTheoryAttribute(string flakyExplanation, int retriesBeforeFail = DefaultRetriesBeforeFail)
     {
         Guard.AgainstNotProvidedFlakyExplanation(flakyExplanation);
         Guard.AgainstInvalidRetries(retriesBeforeFail);
@@ -37,7 +42,7 @@ public class FlakyFactAttribute : FactAttribute, IFlakyAttribute
         FlakyExplanation = flakyExplanation;
         RetriesBeforeFail = retriesBeforeFail;
     }
-    
+
     /// <inheritdoc />
     public string FlakyExplanation { get; }
     

--- a/src/FlakyTest.XUnit/Interfaces/IFlakyAttribute.cs
+++ b/src/FlakyTest.XUnit/Interfaces/IFlakyAttribute.cs
@@ -1,0 +1,22 @@
+﻿namespace FlakyTest.XUnit.Interfaces;
+
+/// <summary>
+/// The required data for marking a test as flaky.
+/// </summary>
+public interface IFlakyAttribute
+{
+    /// <summary>
+    /// The default number of retries before failing a test case.
+    /// </summary>
+    public const int DefaultRetriesBeforeFail = 5;
+    
+    /// <summary>
+    /// The explanation as to why the test case is being annotated as flaky.
+    /// </summary>
+    public string FlakyExplanation { get; }
+
+    /// <summary>
+    /// The number of attempts to retry a test case before deeming it a failed test. 
+    /// </summary>
+    public int RetriesBeforeFail { get; }
+}

--- a/src/FlakyTest.XUnit/Interfaces/IFlakyAttribute.cs
+++ b/src/FlakyTest.XUnit/Interfaces/IFlakyAttribute.cs
@@ -9,7 +9,7 @@ public interface IFlakyAttribute
     /// The default number of retries before failing a test case.
     /// </summary>
     public const int DefaultRetriesBeforeFail = 5;
-    
+
     /// <summary>
     /// The explanation as to why the test case is being annotated as flaky.
     /// </summary>

--- a/src/FlakyTest.XUnit/Services/FlakyTheoryDiscoverer.cs
+++ b/src/FlakyTest.XUnit/Services/FlakyTheoryDiscoverer.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+using FlakyTest.XUnit.Attributes;
+using FlakyTest.XUnit.Interfaces;
+using FlakyTest.XUnit.Models;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace FlakyTest.XUnit.Services;
+
+/// <summary>
+/// Implementation of <see cref="IXunitTestCaseDiscoverer"/> for handling <see cref="FlakyTheoryAttribute"/> decorated
+/// test cases.
+/// </summary>
+public class FlakyTheoryDiscoverer : TheoryDiscoverer
+{
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    /// <param name="diagnosticMessageSink">The default XUnit message sink</param>
+    public FlakyTheoryDiscoverer(IMessageSink diagnosticMessageSink) : base(diagnosticMessageSink) { }
+
+    /// <inheritdoc />
+    protected override IEnumerable<IXunitTestCase> CreateTestCasesForDataRow(
+        ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute, 
+        object[] dataRow)
+    {
+        int retriesBeforeFail = theoryAttribute.GetNamedArgument<int>(nameof(IFlakyAttribute.RetriesBeforeFail));
+        
+        return new[]
+        {
+            new FlakyTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), 
+                discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod, retriesBeforeFail, dataRow)
+        };
+    }
+}

--- a/src/FlakyTest.XUnit/Services/FlakyTheoryDiscoverer.cs
+++ b/src/FlakyTest.XUnit/Services/FlakyTheoryDiscoverer.cs
@@ -21,14 +21,14 @@ public class FlakyTheoryDiscoverer : TheoryDiscoverer
 
     /// <inheritdoc />
     protected override IEnumerable<IXunitTestCase> CreateTestCasesForDataRow(
-        ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute, 
+        ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute,
         object[] dataRow)
     {
         int retriesBeforeFail = theoryAttribute.GetNamedArgument<int>(nameof(IFlakyAttribute.RetriesBeforeFail));
-        
+
         return new[]
         {
-            new FlakyTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), 
+            new FlakyTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(),
                 discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod, retriesBeforeFail, dataRow)
         };
     }

--- a/test/FlakyTest.XUnit.Tests.Integration/FlakyFactTestCaseTests.cs
+++ b/test/FlakyTest.XUnit.Tests.Integration/FlakyFactTestCaseTests.cs
@@ -1,4 +1,5 @@
 ﻿using FlakyTest.XUnit.Attributes;
+using FlakyTest.XUnit.Interfaces;
 using FluentAssertions;
 using Moq;
 using Xunit;
@@ -53,7 +54,7 @@ public class FlakyFactTestCaseTests
         // this will "fail" until we hit the max retries, at which point the assertion will be successful.
         _counterWhenUsingFlakyFactShouldFailUntilHittingDefaultMax
             .Should()
-            .Be(FlakyFactAttribute.DefaultRetriesBeforeFail);
+            .Be(IFlakyAttribute.DefaultRetriesBeforeFail);
     }
 
     private const int CustomRetries = 7;
@@ -67,7 +68,7 @@ public class FlakyFactTestCaseTests
         // Check assumptions
         CustomRetries
             .Should()
-            .NotBe(FlakyFactAttribute.DefaultRetriesBeforeFail,
+            .NotBe(IFlakyAttribute.DefaultRetriesBeforeFail,
                 "we're making sure it differs from the default to ensure it's failing the 'correct' number of times");
 
         // this will "fail" until we hit the max retries, at which point the assertion will be successful.

--- a/test/FlakyTest.XUnit.Tests.Integration/FlakyTheoryTestCaseTests.cs
+++ b/test/FlakyTest.XUnit.Tests.Integration/FlakyTheoryTestCaseTests.cs
@@ -1,0 +1,108 @@
+﻿using FlakyTest.XUnit.Attributes;
+using FlakyTest.XUnit.Interfaces;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace FlakyTest.XUnit.Tests.Integration;
+
+public class FlakyTheoryTestCaseTests
+{
+    private static readonly Mock<IBoolReturner> BoolReturner = new();
+
+    static FlakyTheoryTestCaseTests()
+    {
+        BoolReturner.SetupSequence(s => s.Get())
+            .ReturnsAsync(false)
+            .ReturnsAsync(false)
+            .ReturnsAsync(true);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    public void WhenUsingTheorySync_ShouldBehaveNormally(bool value)
+    {
+        value.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(true)]
+    public async Task WhenUsingTheoryAsync_ShouldBehaveNormally(bool value)
+    {
+        await Task.Delay(1);
+        value.Should().BeTrue();
+    }
+
+    [FlakyTheory("This test isn't actually flaky, want to make sure happy path first run still works as expected for sync tests")]
+    [InlineData(true)]
+    public void WhenUsingFlakyTheorySync_ShouldBehaveNormallyOnSuccessfulRun(bool value)
+    {
+        value.Should().BeTrue();
+    }
+
+    [FlakyTheory("This test isn't actually flaky, want to make sure happy path first run still works as expected for async tests")]
+    [InlineData(true)]
+    public async Task WhenUsingFlakyTheoryAsync_ShouldBehaveNormallyOnSuccessfulRun(bool value)
+    {
+        await Task.Delay(1);
+        value.Should().BeTrue();
+    }
+
+    private static int _counterWhenUsingFlakyTheoryShouldFailUntilHittingDefaultMax;
+
+    [FlakyTheory("Should fail the number of times until hitting the default max")]
+    [InlineData(true)]
+    public void WhenUsingFlakyTheory_ShouldFailUntilHittingDefaultMax(bool value)
+    {
+        value.Should().BeTrue();
+        
+        // This is effectively "state" for each "iteration" of the test run, up to the maximum tries.
+        _counterWhenUsingFlakyTheoryShouldFailUntilHittingDefaultMax++;
+
+        // this will "fail" until we hit the max retries, at which point the assertion will be successful.
+        _counterWhenUsingFlakyTheoryShouldFailUntilHittingDefaultMax
+            .Should()
+            .Be(IFlakyAttribute.DefaultRetriesBeforeFail);
+    }
+
+    private const int CustomRetries = 7;
+    private static int _counterWhenUsingFlakyTheoryShouldFailSpecifiedNumberOfTimesBeforeReportingFailure;
+    [FlakyTheory("Should fail the number of times specified, at which point a success condition is found", CustomRetries)]
+    [InlineData(true)]
+    public void WhenUsingFlakyTheory_ShouldFailSpecifiedNumberOfTimesBeforeReportingFailure(bool value)
+    {
+        value.Should().BeTrue();
+        
+        // This is effectively "state" for each "iteration" of the test run, up to the maximum tries.
+        _counterWhenUsingFlakyTheoryShouldFailSpecifiedNumberOfTimesBeforeReportingFailure++;
+
+        // Check assumptions
+        CustomRetries
+            .Should()
+            .NotBe(IFlakyAttribute.DefaultRetriesBeforeFail,
+                "we're making sure it differs from the default to ensure it's failing the 'correct' number of times");
+
+        // this will "fail" until we hit the max retries, at which point the assertion will be successful.
+        _counterWhenUsingFlakyTheoryShouldFailSpecifiedNumberOfTimesBeforeReportingFailure
+            .Should()
+            .Be(CustomRetries);
+    }
+
+    private static int _counterWhenUsingFlakyTheoryShouldShortCircuitPass;
+    [FlakyTheory("Should short circuit pass successfully", 100)]
+    [InlineData(true)]
+    public async Task WhenUsingFlakyTheory_ShouldShortCircuitPass(bool value)
+    {
+        value.Should().BeTrue();
+        
+        _counterWhenUsingFlakyTheoryShouldShortCircuitPass++;
+
+        // The first two returns will be false, the next is true.
+        // Assert in such a way that only the final one will be "successful".
+        var result = await BoolReturner.Object.Get();
+        result.Should().BeTrue($"should only be true on the 3rd call. On call {_counterWhenUsingFlakyTheoryShouldShortCircuitPass}");
+
+        _counterWhenUsingFlakyTheoryShouldShortCircuitPass
+            .Should().Be(3, "this is the number of retries that occurred prior to hitting a success");
+    }
+}

--- a/test/FlakyTest.XUnit.Tests.Integration/FlakyTheoryTestCaseTests.cs
+++ b/test/FlakyTest.XUnit.Tests.Integration/FlakyTheoryTestCaseTests.cs
@@ -55,7 +55,7 @@ public class FlakyTheoryTestCaseTests
     public void WhenUsingFlakyTheory_ShouldFailUntilHittingDefaultMax(bool value)
     {
         value.Should().BeTrue();
-        
+
         // This is effectively "state" for each "iteration" of the test run, up to the maximum tries.
         _counterWhenUsingFlakyTheoryShouldFailUntilHittingDefaultMax++;
 
@@ -72,7 +72,7 @@ public class FlakyTheoryTestCaseTests
     public void WhenUsingFlakyTheory_ShouldFailSpecifiedNumberOfTimesBeforeReportingFailure(bool value)
     {
         value.Should().BeTrue();
-        
+
         // This is effectively "state" for each "iteration" of the test run, up to the maximum tries.
         _counterWhenUsingFlakyTheoryShouldFailSpecifiedNumberOfTimesBeforeReportingFailure++;
 
@@ -94,7 +94,7 @@ public class FlakyTheoryTestCaseTests
     public async Task WhenUsingFlakyTheory_ShouldShortCircuitPass(bool value)
     {
         value.Should().BeTrue();
-        
+
         _counterWhenUsingFlakyTheoryShouldShortCircuitPass++;
 
         // The first two returns will be false, the next is true.

--- a/test/FlakyTest.XUnit.Tests.Unit/Attributes/FlakyFactAttributeTests.cs
+++ b/test/FlakyTest.XUnit.Tests.Unit/Attributes/FlakyFactAttributeTests.cs
@@ -1,4 +1,5 @@
 ﻿using FlakyTest.XUnit.Attributes;
+using FlakyTest.XUnit.Interfaces;
 using FluentAssertions;
 using Xunit;
 
@@ -19,7 +20,7 @@ public class FlakyFactAttributeTests
     {
         _sut = new FlakyFactAttribute(FlakyTestExplanation);
 
-        _sut.RetriesBeforeFail.Should().Be(FlakyFactAttribute.DefaultRetriesBeforeFail);
+        _sut.RetriesBeforeFail.Should().Be(IFlakyAttribute.DefaultRetriesBeforeFail);
     }
 
     [Theory]


### PR DESCRIPTION
* Refactors a bit of the (now) otherwise duplicated stuff into an interface `IFlakyAttribute`.
* Closes #3

# Description

Adds a `FlakyTheory` attribute that can be used as a flaky test indicator for `Theory` type tests.

Fixes # (issue number)
#3

## Type of Change

Use an `x` in between the `[ ]` for each line applicable to the type of change for this PR

- [ ] Bug fix
- [x] New Feature
- [x] Documentation
- [x] Code improvement
- [ ] Breaking change - if a public API changes, or any change that **_DOES_** or **_MAY_** require a major revision to the NuGet package version due to [semver](https://semver.org/).
- [x] Unit tests
- [x] Code samples
- [ ] Added your repository URL to the readme because you make use of this super cool package! ;)
- [ ] Other

## Describe testing that was performed for your change

Added tests duplicating the ones from `FlakyFact`, but for `FlakyTheory`

## Checklist

- [x] Read the https://github.com/Kritner-Blogs/FlakyTest.XUnit/blob/main/CONTRIBUTING.md
- [x] Ran unit tests and ensured they passed
- [x] Added unit tests where applicable
- [x] Referenced an issue where applicable
- [x] Ran `dotnet-format` locally
