### PR TITLE
Feature/7 check no longer flaky

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # FlakyTest.XUnit
 
-[![Build and test](https://github.com/Kritner-Blogs/FlakyTest.XUnit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Kritner-Blogs/FlakyTest.XUnit/actions/workflows/ci.yml) 
+[![Build and test](https://github.com/Kritner-Blogs/FlakyTest.XUnit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Kritner-Blogs/FlakyTest.XUnit/actions/workflows/ci.yml)
 
-![Latest NuGet Version](https://img.shields.io/nuget/v/FlakyTest.XUnit) 
+![Latest NuGet Version](https://img.shields.io/nuget/v/FlakyTest.XUnit)
 ![License](https://img.shields.io/github/license/Kritner-Blogs/FlakyTest.XUnit)
 
 ## Overview
@@ -13,7 +13,11 @@ If you still want an easy way to mark a test or two (but no more than that!) as 
 
 ## Usage
 
-It probably can't get much easier to consume this functionality.  If you're already used to decorating your test methods with `[Fact]` you're almost there!
+### `FlakyFact` / `FlakyTheory`
+
+It probably can't get much easier to consume this functionality. If you're already used to decorating your test methods with `[Fact]` you're almost there!
+
+#### Example
 
 ```cs
 using FlakyTest.XUnit.Attributes;
@@ -33,6 +37,36 @@ public async Task WhenDoingThing_ShouldHaveThisResult(bool isDoots)
 }
 ```
 
-The project *requires* the first string parameter `flakyExplanation` to be not null/empty... cuz you really shouldn't be using this anyway.  This can be used as a way to describe how/why the test is flaky, and perhaps leave a note and ticket for follow up to get the flakyness aspect of the test fixed.
+The project _requires_ the first string parameter `flakyExplanation` to be not null/empty... cuz you really shouldn't be using this anyway. This can be used as a way to describe how/why the test is flaky, and perhaps leave a note and ticket for follow up to get the flakyness aspect of the test fixed.
 
-The second parameter indicates how many times the test can "fail" before the test runner actually reports it as failure.  The default value here (at the time of writing this) is 5 - meaning the test can fail 5 times prior to the runner reporting it as a failure.  If the test *passes* on the first, fourth, or any test in between, it is immediately marked as successful to the runner.
+The second parameter indicates how many times the test can "fail" before the test runner actually reports it as failure. The default value here (at the time of writing this) is 5 - meaning the test can fail 5 times prior to the runner reporting it as a failure. If the test _passes_ on the first, fourth, or any test in between, it is immediately marked as successful to the runner.
+
+### `MaybeFixedFact` / `MaybeFixedTheory`
+
+Did you have a test your were previously decorating as `Flaky`? Have you made updates to the code or test and want to check that it's no longer flaky? Well the attributes `MaybeFixedFact` and `MaybeFixedTheory` may be for you!
+
+Use these attributes to signal to the test runner that the tests decorated as such should be run `x` times to consider them "successful".
+
+If `x` is 10, the test will be run up to 10x. The runner will bail early if a failure is encountered up to `x`, once `x` is arrived at with _all_ passing tests, the test is considered an overall disposition of "passed". This `x` value is configurable, but is 10 by default (at the time of writing this documentation anyway).
+
+#### Example
+
+```cs
+using FlakyTest.XUnit.Attributes;
+
+[MaybeFixedFact(42)]
+public async Task WhenDoingThing_ShouldHaveThisResult()
+{
+   // your test implementation which was sometimes flaky
+   // checking now that it's no longer flaky by running
+   // the test 42 times before (and they must all be individually passing) being considered a passed test
+}
+
+[FlakyTheory]
+[InlineData(true)]
+[InlineData(false)]
+public async Task WhenDoingThing_ShouldHaveThisResult(bool isDoots)
+{
+   // your test implementation which was sometimes flaky
+}
+```

--- a/src/FlakyTest.XUnit/Attributes/FlakyTheoryAttribute.cs
+++ b/src/FlakyTest.XUnit/Attributes/FlakyTheoryAttribute.cs
@@ -25,16 +25,11 @@ namespace FlakyTest.XUnit.Attributes;
 public class FlakyTheoryAttribute : TheoryAttribute, IFlakyAttribute
 {
     /// <summary>
-    /// The default number of retries before failing a test case.
-    /// </summary>
-    public const int DefaultRetriesBeforeFail = 5;
-
-    /// <summary>
     /// Constructor
     /// </summary>
     /// <param name="flakyExplanation">The explanation to why the test is being marked flaky.</param>
     /// <param name="retriesBeforeFail">The number of retries prior to marking a test as failed.</param>
-    public FlakyTheoryAttribute(string flakyExplanation, int retriesBeforeFail = DefaultRetriesBeforeFail)
+    public FlakyTheoryAttribute(string flakyExplanation, int retriesBeforeFail = IFlakyAttribute.DefaultRetriesBeforeFail)
     {
         Guard.AgainstNotProvidedFlakyExplanation(flakyExplanation);
         Guard.AgainstInvalidRetries(retriesBeforeFail);

--- a/src/FlakyTest.XUnit/Attributes/MaybeFixedFactAttribute.cs
+++ b/src/FlakyTest.XUnit/Attributes/MaybeFixedFactAttribute.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using FlakyTest.XUnit.Guards;
+using FlakyTest.XUnit.Interfaces;
+using Xunit;
+using Xunit.Sdk;
+
+namespace FlakyTest.XUnit.Attributes;
+
+/// <summary>
+/// <para>
+/// Use of this attribute indicates a maybe fixed test (when it was previously flaky).
+/// </para>
+/// <para>
+/// This attribute can be used to run a test multiple times, only "passing" if each attempt at the test passes, up to
+/// the total number of tests desired and specified in the attribute.
+/// </para>
+/// </summary>
+[XunitTestCaseDiscoverer("FlakyTest.XUnit.Services.MaybeFixedFactDiscoverer", "FlakyTest.XUnit")]
+[AttributeUsage(AttributeTargets.Method)]
+public class MaybeFixedFactAttribute : FactAttribute, IMaybeFixedAttribute
+{
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    /// <param name="retriesBeforeDeemingNoLongerFlaky">The number of retries prior to marking a test as failed.</param>
+    public MaybeFixedFactAttribute(
+        int retriesBeforeDeemingNoLongerFlaky = IMaybeFixedAttribute.DefaultRetriesBeforeDeemingNoLongerFlaky)
+    {
+        Guard.AgainstInvalidRetries(retriesBeforeDeemingNoLongerFlaky);
+
+        RetriesBeforeDeemingNoLongerFlaky = retriesBeforeDeemingNoLongerFlaky;
+    }
+
+    /// <inheritdoc />
+    public int RetriesBeforeDeemingNoLongerFlaky { get; }
+}

--- a/src/FlakyTest.XUnit/Attributes/MaybeFixedTheoryAttribute.cs
+++ b/src/FlakyTest.XUnit/Attributes/MaybeFixedTheoryAttribute.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using FlakyTest.XUnit.Guards;
+using FlakyTest.XUnit.Interfaces;
+using Xunit;
+using Xunit.Sdk;
+
+namespace FlakyTest.XUnit.Attributes;
+
+/// <summary>
+/// <para>
+/// Use of this attribute indicates a maybe fixed test (when it was previously flaky).
+/// </para>
+/// <para>
+/// This attribute can be used to run a test multiple times, only "passing" if each attempt at the test passes, up to
+/// the total number of tests desired and specified in the attribute.
+/// </para>
+/// </summary>
+[XunitTestCaseDiscoverer("FlakyTest.XUnit.Services.MaybeFixedTheoryDiscoverer", "FlakyTest.XUnit")]
+[AttributeUsage(AttributeTargets.Method)]
+public class MaybeFixedTheoryAttribute : TheoryAttribute, IMaybeFixedAttribute
+{
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    /// <param name="retriesBeforeDeemingNoLongerFlaky">The number of retries prior to marking a test as failed.</param>
+    public MaybeFixedTheoryAttribute(
+        int retriesBeforeDeemingNoLongerFlaky = IMaybeFixedAttribute.DefaultRetriesBeforeDeemingNoLongerFlaky)
+    {
+        Guard.AgainstInvalidRetries(retriesBeforeDeemingNoLongerFlaky);
+
+        RetriesBeforeDeemingNoLongerFlaky = retriesBeforeDeemingNoLongerFlaky;
+    }
+
+    /// <inheritdoc />
+    public int RetriesBeforeDeemingNoLongerFlaky { get; }
+}

--- a/src/FlakyTest.XUnit/FlakyTest.XUnit.csproj
+++ b/src/FlakyTest.XUnit/FlakyTest.XUnit.csproj
@@ -6,7 +6,7 @@
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>
-    <PackageReadmeFile>README.md</PackageReadmeFile>    
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
@@ -38,7 +38,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>$(AssemblyName).Tests.Unit</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
 
 </Project>

--- a/src/FlakyTest.XUnit/Guards/Guard.cs
+++ b/src/FlakyTest.XUnit/Guards/Guard.cs
@@ -5,14 +5,14 @@ namespace FlakyTest.XUnit.Guards;
 /// <summary>
 /// Helper guard classes against invalid use.
 /// </summary>
-public static class Guard
+internal static class Guard
 {
     /// <summary>
     /// A guard that protects against an empty or null flakyException.
     /// </summary>
     /// <param name="flakyExplanation">The string flaky explanation to evaluate.</param>
     /// <exception cref="FlakyExplanationException">Thrown when the explanation is null or empty.</exception>
-    public static void AgainstNotProvidedFlakyExplanation(string flakyExplanation)
+    internal static void AgainstNotProvidedFlakyExplanation(string flakyExplanation)
     {
         if (string.IsNullOrEmpty(flakyExplanation))
             throw new FlakyExplanationException();
@@ -25,7 +25,7 @@ public static class Guard
     /// <exception cref="InvalidNumberOfRetriesException">
     /// Thrown when the number of retries is less than or equal to zero.
     /// </exception>
-    public static void AgainstInvalidRetries(int retriesBeforeFail)
+    internal static void AgainstInvalidRetries(int retriesBeforeFail)
     {
         if (retriesBeforeFail <= 0)
             throw new InvalidNumberOfRetriesException();

--- a/src/FlakyTest.XUnit/Interfaces/IMaybeFixedAttribute.cs
+++ b/src/FlakyTest.XUnit/Interfaces/IMaybeFixedAttribute.cs
@@ -1,0 +1,24 @@
+﻿namespace FlakyTest.XUnit.Interfaces;
+
+/// <summary>
+/// <para>
+/// The attributes that implement this interface can be used to run a test up to a specified number of times
+/// to attempt to determine if the test is *still* flaky (or fixed).
+/// </para>
+/// <para>
+/// A situation where you *had* a flaky test, have made corrections to the underlying code or test, and want to confirm
+/// that the test is no longer flaky, would be a good use case for such attributes.
+/// </para>
+/// </summary>
+public interface IMaybeFixedAttribute
+{
+    /// <summary>
+    /// The default number of successful runs of the test to "pass" and consider no longer flaky.
+    /// </summary>
+    public const int DefaultRetriesBeforeDeemingNoLongerFlaky = 10;
+
+    /// <summary>
+    /// The number of successful runs of the test to "pass" and consider no longer flaky. 
+    /// </summary>
+    public int RetriesBeforeDeemingNoLongerFlaky { get; }
+}

--- a/src/FlakyTest.XUnit/Interfaces/IMaybeFixedTestCase.cs
+++ b/src/FlakyTest.XUnit/Interfaces/IMaybeFixedTestCase.cs
@@ -1,0 +1,14 @@
+﻿using Xunit.Sdk;
+
+namespace FlakyTest.XUnit.Interfaces;
+
+/// <summary>
+/// Implements <see cref="IXunitTestCase"/> and adds the additional properties necessary for retrying.
+/// </summary>
+public interface IMaybeFixedTestCase : IXunitTestCase
+{
+    /// <summary>
+    /// The number of successful runs of the test to "pass" and consider no longer flaky.
+    /// </summary>
+    int RetriesBeforeDeemingNoLongerFlaky { get; }
+}

--- a/src/FlakyTest.XUnit/Models/FlakyTestCase.cs
+++ b/src/FlakyTest.XUnit/Models/FlakyTestCase.cs
@@ -36,9 +36,7 @@ public class FlakyTestCase : XunitTestCase, IFlakyTestCase
         RetriesBeforeFail = retriesBeforeFail;
     }
 
-    /// <summary>
-    /// Number of retries prior to being deemed a failing test.
-    /// </summary>
+    /// <inheritdoc />
     public int RetriesBeforeFail { get; private set; }
 
     /// <inheritdoc />
@@ -92,7 +90,7 @@ public class FlakyTestCase : XunitTestCase, IFlakyTestCase
                 {
                     diagnosticMessageSink.OnMessage(new DiagnosticMessage(
                         "The test '{0}' reports failure after {1} attempts.",
-                        testCase.DisplayName, testCase.RetriesBeforeFail));
+                        testCase.DisplayName, attempt));
                 }
 
                 flakyTestMessageBus.Flush();

--- a/src/FlakyTest.XUnit/Services/FlakyFactDiscoverer.cs
+++ b/src/FlakyTest.XUnit/Services/FlakyFactDiscoverer.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using FlakyTest.XUnit.Attributes;
+using FlakyTest.XUnit.Interfaces;
 using FlakyTest.XUnit.Models;
 using Xunit.Abstractions;
 using Xunit.Sdk;
@@ -28,7 +29,7 @@ public class FlakyFactDiscoverer : IXunitTestCaseDiscoverer
     public IEnumerable<IXunitTestCase> Discover(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod,
         IAttributeInfo factAttribute)
     {
-        var retriesBeforeFail = factAttribute.GetNamedArgument<int>(nameof(FlakyFactAttribute.RetriesBeforeFail));
+        var retriesBeforeFail = factAttribute.GetNamedArgument<int>(nameof(IFlakyAttribute.RetriesBeforeFail));
 
         IXunitTestCase testCase = new FlakyTestCase(_messageSink, discoveryOptions.MethodDisplayOrDefault(),
             discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod, retriesBeforeFail);

--- a/src/FlakyTest.XUnit/Services/MaybeFixedFactDiscoverer.cs
+++ b/src/FlakyTest.XUnit/Services/MaybeFixedFactDiscoverer.cs
@@ -1,0 +1,39 @@
+﻿using System.Collections.Generic;
+using FlakyTest.XUnit.Attributes;
+using FlakyTest.XUnit.Interfaces;
+using FlakyTest.XUnit.Models;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace FlakyTest.XUnit.Services;
+
+/// <summary>
+/// Implementation of <see cref="IXunitTestCaseDiscoverer"/> for handling <see cref="MaybeFixedFactAttribute"/> decorated
+/// test cases.
+/// </summary>
+/// <inheritdoc />
+public class MaybeFixedFactDiscoverer : IXunitTestCaseDiscoverer
+{
+    private readonly IMessageSink _messageSink;
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    /// <param name="messageSink">The default XUnit message sink</param>
+    public MaybeFixedFactDiscoverer(IMessageSink messageSink)
+    {
+        _messageSink = messageSink;
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<IXunitTestCase> Discover(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod,
+        IAttributeInfo factAttribute)
+    {
+        var retriesBeforeDeemingNoLongerFlaky = factAttribute.GetNamedArgument<int>(nameof(IMaybeFixedAttribute.RetriesBeforeDeemingNoLongerFlaky));
+
+        IXunitTestCase testCase = new MaybeFixedTestCase(_messageSink, discoveryOptions.MethodDisplayOrDefault(),
+            discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod, retriesBeforeDeemingNoLongerFlaky);
+
+        return new[] { testCase };
+    }
+}

--- a/src/FlakyTest.XUnit/Services/MaybeFixedTheoryDiscoverer.cs
+++ b/src/FlakyTest.XUnit/Services/MaybeFixedTheoryDiscoverer.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+using FlakyTest.XUnit.Attributes;
+using FlakyTest.XUnit.Interfaces;
+using FlakyTest.XUnit.Models;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace FlakyTest.XUnit.Services;
+
+/// <summary>
+/// Implementation of <see cref="IXunitTestCaseDiscoverer"/> for handling <see cref="MaybeFixedTheoryAttribute"/> decorated
+/// test cases.
+/// </summary>
+/// <inheritdoc />
+public class MaybeFixedTheoryDiscoverer : TheoryDiscoverer
+{
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    /// <param name="diagnosticMessageSink">The default XUnit message sink</param>
+    public MaybeFixedTheoryDiscoverer(IMessageSink diagnosticMessageSink) : base(diagnosticMessageSink) { }
+
+    /// <inheritdoc />
+    protected override IEnumerable<IXunitTestCase> CreateTestCasesForDataRow(
+        ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute,
+        object[] dataRow)
+    {
+        int retriesBeforeFail = theoryAttribute.GetNamedArgument<int>(nameof(IFlakyAttribute.RetriesBeforeFail));
+
+        return new[]
+        {
+            new FlakyTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(),
+                discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod, retriesBeforeFail, dataRow)
+        };
+    }
+}

--- a/test/FlakyTest.XUnit.Tests.Integration/FlakyFactTestCaseTests.cs
+++ b/test/FlakyTest.XUnit.Tests.Integration/FlakyFactTestCaseTests.cs
@@ -1,11 +1,17 @@
 ﻿using FlakyTest.XUnit.Attributes;
 using FlakyTest.XUnit.Interfaces;
+using FlakyTest.XUnit.Models;
+using FlakyTest.XUnit.Services;
 using FluentAssertions;
 using Moq;
 using Xunit;
 
 namespace FlakyTest.XUnit.Tests.Integration;
 
+/// <summary>
+/// Tests checking against behaviors/interactions between <see cref="FlakyFactAttribute"/>, <see cref="FlakyFactDiscoverer"/>
+/// and <see cref="FlakyTestCase"/>.
+/// </summary>
 public class FlakyFactTestCaseTests
 {
     private static readonly Mock<IBoolReturner> BoolReturner = new();

--- a/test/FlakyTest.XUnit.Tests.Integration/FlakyTheoryTestCaseTests.cs
+++ b/test/FlakyTest.XUnit.Tests.Integration/FlakyTheoryTestCaseTests.cs
@@ -1,11 +1,17 @@
 ﻿using FlakyTest.XUnit.Attributes;
 using FlakyTest.XUnit.Interfaces;
+using FlakyTest.XUnit.Models;
+using FlakyTest.XUnit.Services;
 using FluentAssertions;
 using Moq;
 using Xunit;
 
 namespace FlakyTest.XUnit.Tests.Integration;
 
+/// <summary>
+/// Tests checking against behaviors/interactions between <see cref="FlakyTheoryAttribute"/>, <see cref="FlakyTheoryDiscoverer"/>
+/// and <see cref="FlakyTestCase"/>.
+/// </summary>
 public class FlakyTheoryTestCaseTests
 {
     private static readonly Mock<IBoolReturner> BoolReturner = new();

--- a/test/FlakyTest.XUnit.Tests.Integration/MaybeFixedFactTestCaseTests.cs
+++ b/test/FlakyTest.XUnit.Tests.Integration/MaybeFixedFactTestCaseTests.cs
@@ -1,0 +1,72 @@
+﻿using FlakyTest.XUnit.Attributes;
+using FlakyTest.XUnit.Interfaces;
+using FlakyTest.XUnit.Models;
+using FlakyTest.XUnit.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace FlakyTest.XUnit.Tests.Integration;
+
+/// <summary>
+/// Tests checking against behaviors/interactions between <see cref="MaybeFixedFactAttribute"/>, <see cref="MaybeFixedFactDiscoverer"/>
+/// and <see cref="MaybeFixedTestCase"/>.
+/// </summary>
+public class MaybeFixedFactTestCaseTests
+{
+    [Fact]
+    public void WhenUsingFactsSync_ShouldBehaveNormally()
+    {
+        true.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task WhenUsingFactsAsync_ShouldBehaveNormally()
+    {
+        await Task.Delay(1);
+        true.Should().BeTrue();
+    }
+
+    [MaybeFixedFact]
+    public void WhenUsingMaybeFixedFactSync_ShouldBehaveNormallyOnSuccessfulRun()
+    {
+        true.Should().BeTrue();
+    }
+
+    [MaybeFixedFact]
+    public async Task WhenUsingMaybeFixedFactAsync_ShouldBehaveNormallyOnSuccessfulRun()
+    {
+        await Task.Delay(1);
+        true.Should().BeTrue();
+    }
+
+    private static int _counterWhenUsingMaybeFixedFactShouldRunUntilHittingDefaultMax;
+    [MaybeFixedFact]
+    public void WhenUsingMaybeFixedFact_ShouldRunUntilHittingDefaultMax()
+    {
+        // This is effectively "state" for each "iteration" of the test run, up to the maximum tries.
+        _counterWhenUsingMaybeFixedFactShouldRunUntilHittingDefaultMax++;
+
+        _counterWhenUsingMaybeFixedFactShouldRunUntilHittingDefaultMax
+            .Should()
+            .BeLessOrEqualTo(IMaybeFixedAttribute.DefaultRetriesBeforeDeemingNoLongerFlaky);
+    }
+
+    private const int CustomRetries = 7;
+    private static int _counterWhenUsingMaybeFixedFactShouldPassExpectedNumberOfTimes;
+    [MaybeFixedFact(CustomRetries)]
+    public void WhenUsingMaybeFixedFact_ShouldPassExpectedNumberOfTimes()
+    {
+        // This is effectively "state" for each "iteration" of the test run, up to the maximum tries.
+        _counterWhenUsingMaybeFixedFactShouldPassExpectedNumberOfTimes++;
+
+        // Check assumptions
+        CustomRetries
+            .Should()
+            .NotBe(IMaybeFixedAttribute.DefaultRetriesBeforeDeemingNoLongerFlaky,
+                "we're making sure it differs from the default");
+
+        _counterWhenUsingMaybeFixedFactShouldPassExpectedNumberOfTimes
+            .Should()
+            .BeLessOrEqualTo(CustomRetries);
+    }
+}

--- a/test/FlakyTest.XUnit.Tests.Integration/MaybeFixedTheoryTestCaseTests.cs
+++ b/test/FlakyTest.XUnit.Tests.Integration/MaybeFixedTheoryTestCaseTests.cs
@@ -1,0 +1,82 @@
+﻿using FlakyTest.XUnit.Attributes;
+using FlakyTest.XUnit.Interfaces;
+using FlakyTest.XUnit.Models;
+using FlakyTest.XUnit.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace FlakyTest.XUnit.Tests.Integration;
+
+/// <summary>
+/// Tests checking against behaviors/interactions between <see cref="MaybeFixedTheoryAttribute"/>, <see cref="MaybeFixedTheoryDiscoverer"/>
+/// and <see cref="MaybeFixedTestCase"/>.
+/// </summary>
+public class MaybeFixedTheoryTestCaseTests
+{
+    [Theory]
+    [InlineData(true)]
+    public void WhenUsingTheorysSync_ShouldBehaveNormally(bool value)
+    {
+        value.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(true)]
+    public async Task WhenUsingTheorysAsync_ShouldBehaveNormally(bool value)
+    {
+        await Task.Delay(1);
+        value.Should().BeTrue();
+    }
+
+    [MaybeFixedTheory]
+    [InlineData(true)]
+    public void WhenUsingMaybeFixedTheorySync_ShouldBehaveNormallyOnSuccessfulRun(bool value)
+    {
+        value.Should().BeTrue();
+    }
+
+    [MaybeFixedTheory]
+    [InlineData(true)]
+    public async Task WhenUsingMaybeFixedTheoryAsync_ShouldBehaveNormallyOnSuccessfulRun(bool value)
+    {
+        await Task.Delay(1);
+        value.Should().BeTrue();
+    }
+
+    private static int _counterWhenUsingMaybeFixedTheoryShouldRunUntilHittingDefaultMax;
+    [MaybeFixedTheory]
+    [InlineData(true)]
+    public void WhenUsingMaybeFixedTheory_ShouldRunUntilHittingDefaultMax(bool value)
+    {
+        // This is effectively "state" for each "iteration" of the test run, up to the maximum tries.
+        _counterWhenUsingMaybeFixedTheoryShouldRunUntilHittingDefaultMax++;
+
+        value.Should().BeTrue();
+
+        _counterWhenUsingMaybeFixedTheoryShouldRunUntilHittingDefaultMax
+            .Should()
+            .BeLessOrEqualTo(IMaybeFixedAttribute.DefaultRetriesBeforeDeemingNoLongerFlaky);
+    }
+
+    private const int CustomRetries = 7;
+    private static int _counterWhenUsingMaybeFixedTheoryShouldPassExpectedNumberOfTimes;
+    [MaybeFixedTheory(CustomRetries)]
+    [InlineData(true)]
+    public void WhenUsingMaybeFixedTheory_ShouldPassExpectedNumberOfTimes(bool value)
+    {
+        // This is effectively "state" for each "iteration" of the test run, up to the maximum tries.
+        _counterWhenUsingMaybeFixedTheoryShouldPassExpectedNumberOfTimes++;
+
+        value.Should().BeTrue();
+
+        // Check assumptions
+        CustomRetries
+            .Should()
+            .NotBe(IMaybeFixedAttribute.DefaultRetriesBeforeDeemingNoLongerFlaky,
+                "we're making sure it differs from the default");
+
+        _counterWhenUsingMaybeFixedTheoryShouldPassExpectedNumberOfTimes
+            .Should()
+            .BeLessOrEqualTo(CustomRetries);
+    }
+}

--- a/test/FlakyTest.XUnit.Tests.Unit/Attributes/FlakyTheoryAttributeTests.cs
+++ b/test/FlakyTest.XUnit.Tests.Unit/Attributes/FlakyTheoryAttributeTests.cs
@@ -1,0 +1,46 @@
+﻿using FlakyTest.XUnit.Attributes;
+using FlakyTest.XUnit.Interfaces;
+using FluentAssertions;
+using Xunit;
+
+namespace FlakyTest.XUnit.Tests.Unit.Attributes;
+
+/// <summary>
+/// Tests against the <see cref="FlakyTheoryAttribute"/> class.
+/// </summary>
+public class FlakyTheoryAttributeTests
+{
+    private FlakyTheoryAttribute? _sut;
+
+    private const string FlakyTestExplanation =
+        "This test is flaky because of an unstable API... further investigation and fixing should be done in JIRA-1234";
+
+    [Fact]
+    public void ctor_WhenGivenNoRetryCount_ShouldUseDefault()
+    {
+        _sut = new FlakyTheoryAttribute(FlakyTestExplanation);
+
+        _sut.RetriesBeforeFail.Should().Be(IFlakyAttribute.DefaultRetriesBeforeFail);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(7)]
+    [InlineData(42)]
+    public void ctor_WhenGivenRetryCount_ShouldSetRetryCount(int retryCount)
+    {
+        _sut = new FlakyTheoryAttribute(FlakyTestExplanation, retryCount);
+
+        _sut.RetriesBeforeFail.Should().Be(retryCount);
+    }
+
+    [Theory]
+    [InlineData(FlakyTestExplanation)]
+    [InlineData("fixed stuff")]
+    public void ctor_WhenGivenFlakyReason_ShouldSetFlakyReason(string flakyReason)
+    {
+        _sut = new FlakyTheoryAttribute(flakyReason);
+
+        _sut.FlakyExplanation.Should().Be(flakyReason);
+    }
+}

--- a/test/FlakyTest.XUnit.Tests.Unit/Attributes/MaybeFixedFactAttributeTests.cs
+++ b/test/FlakyTest.XUnit.Tests.Unit/Attributes/MaybeFixedFactAttributeTests.cs
@@ -1,0 +1,33 @@
+﻿using FlakyTest.XUnit.Attributes;
+using FlakyTest.XUnit.Interfaces;
+using FluentAssertions;
+using Xunit;
+
+namespace FlakyTest.XUnit.Tests.Unit.Attributes;
+
+/// <summary>
+/// Tests against the <see cref="MaybeFixedFactAttribute"/> class.
+/// </summary>
+public class MaybeFixedFactAttributeTests
+{
+    private MaybeFixedFactAttribute? _sut;
+
+    [Fact]
+    public void ctor_WhenGivenNoRetryCount_ShouldUseDefault()
+    {
+        _sut = new MaybeFixedFactAttribute();
+
+        _sut.RetriesBeforeDeemingNoLongerFlaky.Should().Be(IMaybeFixedAttribute.DefaultRetriesBeforeDeemingNoLongerFlaky);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(7)]
+    [InlineData(42)]
+    public void ctor_WhenGivenRetryCount_ShouldSetRetryCount(int retryCount)
+    {
+        _sut = new MaybeFixedFactAttribute(retryCount);
+
+        _sut.RetriesBeforeDeemingNoLongerFlaky.Should().Be(retryCount);
+    }
+}

--- a/test/FlakyTest.XUnit.Tests.Unit/Attributes/MaybeFixedTheoryAttributeTests.cs
+++ b/test/FlakyTest.XUnit.Tests.Unit/Attributes/MaybeFixedTheoryAttributeTests.cs
@@ -1,0 +1,33 @@
+﻿using FlakyTest.XUnit.Attributes;
+using FlakyTest.XUnit.Interfaces;
+using FluentAssertions;
+using Xunit;
+
+namespace FlakyTest.XUnit.Tests.Unit.Attributes;
+
+/// <summary>
+/// Tests against the <see cref="MaybeFixedTheoryAttribute"/> class.
+/// </summary>
+public class MaybeFixedTheoryAttributeTests
+{
+    private MaybeFixedTheoryAttribute? _sut;
+
+    [Fact]
+    public void ctor_WhenGivenNoRetryCount_ShouldUseDefault()
+    {
+        _sut = new MaybeFixedTheoryAttribute();
+
+        _sut.RetriesBeforeDeemingNoLongerFlaky.Should().Be(IMaybeFixedAttribute.DefaultRetriesBeforeDeemingNoLongerFlaky);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(7)]
+    [InlineData(42)]
+    public void ctor_WhenGivenRetryCount_ShouldSetRetryCount(int retryCount)
+    {
+        _sut = new MaybeFixedTheoryAttribute(retryCount);
+
+        _sut.RetriesBeforeDeemingNoLongerFlaky.Should().Be(retryCount);
+    }
+}

--- a/test/FlakyTest.XUnit.Tests.Unit/Guards/GuardTests.cs
+++ b/test/FlakyTest.XUnit.Tests.Unit/Guards/GuardTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 namespace FlakyTest.XUnit.Tests.Unit.Guards;
 
 /// <summary>
-/// Tests against the <see cref="Guard"/> methods.
+/// Tests against the <see cref="FlakyTest.XUnit.Guards.Guard"/> methods.
 /// </summary>
 public class GuardTests
 {

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.1-prerelease",
+  "version": "2.0-prerelease",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/RELEASE/v\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
# Description

* Adds a new set of attributes (`MaybeFixedFact` and `MaybeFixedTheory`) that allow for the running of the decorated tests in a loop, attempting to determine if the test is still "flaky", or if it is now "fixed".  These new attributes likely don't make sense in production code, just as an interim step to getting to a production build to ensure code/tests have been changed in such a way that the test can be considered no longer flaky.
* Fixes the use of a variable in one of the diagnostic messages from the original `FlakyFact` and `FlakyTheory`, was using the max retries var rather than current attempt var
* Revs major revision since some classes were changed from `public` to `internal`

Fixes # (issue number)
#7 

## Type of Change

Use an `x` in between the `[ ]` for each line applicable to the type of change for this PR

- [x] Bug fix
- [x] New Feature
- [x] Documentation
- [x] Code improvement
- [x] Breaking change - if a public API changes, or any change that **_DOES_** or **_MAY_** require a major revision to the NuGet package version due to [semver](https://semver.org/).
- [x] Unit tests
- [x] Code samples
- [ ] Added your repository URL to the readme because you make use of this super cool package! ;)
- [ ] Other

## Describe testing that was performed for your change

Added new tests more or less mirroring the tests that were introduced from `FlakyFact` and `FlakyTheory`, just in the "opposite direction".  Did not put in a test for checking the short circuiting behavior of the new `MaybeFixedFact`/`MaybeFixedTheory` - was having trouble figuring out how to "fail the test" but consider it a pass, on a specific iteration through the retries.

## Checklist

- [x] Read the https://github.com/Kritner-Blogs/FlakyTest.XUnit/blob/main/CONTRIBUTING.md
- [x] Ran unit tests and ensured they passed
- [x] Added unit tests where applicable
- [x] Referenced an issue where applicable
- [x] Ran `dotnet-format` locally
