### PR TITLE
"Skip" attribute testing, fix bug in `MaybeFixedTheoryDiscoverer`

### DIFF
--- a/src/FlakyTest.XUnit/FlakyTest.XUnit.csproj
+++ b/src/FlakyTest.XUnit/FlakyTest.XUnit.csproj
@@ -6,6 +6,7 @@
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>
+    <IsTestProject>false</IsTestProject>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 

--- a/src/FlakyTest.XUnit/Services/MaybeFixedTheoryDiscoverer.cs
+++ b/src/FlakyTest.XUnit/Services/MaybeFixedTheoryDiscoverer.cs
@@ -25,12 +25,12 @@ public class MaybeFixedTheoryDiscoverer : TheoryDiscoverer
         ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute,
         object[] dataRow)
     {
-        int retriesBeforeFail = theoryAttribute.GetNamedArgument<int>(nameof(IFlakyAttribute.RetriesBeforeFail));
+        int retriesBeforeDeemingNoLongerFlaky = theoryAttribute.GetNamedArgument<int>(nameof(IMaybeFixedAttribute.RetriesBeforeDeemingNoLongerFlaky));
 
         return new[]
         {
             new FlakyTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(),
-                discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod, retriesBeforeFail, dataRow)
+                discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod, retriesBeforeDeemingNoLongerFlaky, dataRow)
         };
     }
 }

--- a/test/FlakyTest.XUnit.Tests.Integration/FlakyFactTestCaseTests.cs
+++ b/test/FlakyTest.XUnit.Tests.Integration/FlakyFactTestCaseTests.cs
@@ -97,4 +97,11 @@ public class FlakyFactTestCaseTests
         _counterWhenUsingFlakyFactShouldShortCircuitPass
             .Should().Be(3, "this is the number of retries that occurred prior to hitting a success");
     }
+
+    [FlakyFact("Should work (skip) with skip", Skip = "skipping")]
+    public async Task WhenUsedWithSkip_ShouldSkip()
+    {
+        await Task.Delay(10_000);
+        true.Should().BeFalse("this assert will always fail, but the test should be skipped so it doesn't matter");
+    }
 }

--- a/test/FlakyTest.XUnit.Tests.Integration/FlakyTheoryTestCaseTests.cs
+++ b/test/FlakyTest.XUnit.Tests.Integration/FlakyTheoryTestCaseTests.cs
@@ -111,7 +111,7 @@ public class FlakyTheoryTestCaseTests
         _counterWhenUsingFlakyTheoryShouldShortCircuitPass
             .Should().Be(3, "this is the number of retries that occurred prior to hitting a success");
     }
-    
+
     [FlakyTheory("Should work (skip) with skip", Skip = "skipping")]
     [InlineData(true, Skip = "skipping")]
     public async Task WhenUsedWithSkipTheory_ShouldSkip(bool value)
@@ -119,7 +119,7 @@ public class FlakyTheoryTestCaseTests
         await Task.Delay(10_000);
         value.Should().BeFalse("this assert will always fail, but the test should be skipped so it doesn't matter");
     }
-    
+
     [FlakyTheory("Should work (skip) with skip")]
     [InlineData(true, Skip = "skipping")]
     public async Task WhenUsedWithSkipInlineData_ShouldSkip(bool value)

--- a/test/FlakyTest.XUnit.Tests.Integration/FlakyTheoryTestCaseTests.cs
+++ b/test/FlakyTest.XUnit.Tests.Integration/FlakyTheoryTestCaseTests.cs
@@ -111,4 +111,20 @@ public class FlakyTheoryTestCaseTests
         _counterWhenUsingFlakyTheoryShouldShortCircuitPass
             .Should().Be(3, "this is the number of retries that occurred prior to hitting a success");
     }
+    
+    [FlakyTheory("Should work (skip) with skip", Skip = "skipping")]
+    [InlineData(true, Skip = "skipping")]
+    public async Task WhenUsedWithSkipTheory_ShouldSkip(bool value)
+    {
+        await Task.Delay(10_000);
+        value.Should().BeFalse("this assert will always fail, but the test should be skipped so it doesn't matter");
+    }
+    
+    [FlakyTheory("Should work (skip) with skip")]
+    [InlineData(true, Skip = "skipping")]
+    public async Task WhenUsedWithSkipInlineData_ShouldSkip(bool value)
+    {
+        await Task.Delay(10_000);
+        value.Should().BeFalse("this assert will always fail, but the test should be skipped so it doesn't matter");
+    }
 }

--- a/test/FlakyTest.XUnit.Tests.Integration/MaybeFixedFactTestCaseTests.cs
+++ b/test/FlakyTest.XUnit.Tests.Integration/MaybeFixedFactTestCaseTests.cs
@@ -69,7 +69,7 @@ public class MaybeFixedFactTestCaseTests
             .Should()
             .BeLessOrEqualTo(CustomRetries);
     }
-    
+
     [MaybeFixedFact(Skip = "skipping")]
     public async Task WhenUsedWithSkip_ShouldSkip()
     {

--- a/test/FlakyTest.XUnit.Tests.Integration/MaybeFixedFactTestCaseTests.cs
+++ b/test/FlakyTest.XUnit.Tests.Integration/MaybeFixedFactTestCaseTests.cs
@@ -69,4 +69,11 @@ public class MaybeFixedFactTestCaseTests
             .Should()
             .BeLessOrEqualTo(CustomRetries);
     }
+    
+    [MaybeFixedFact(Skip = "skipping")]
+    public async Task WhenUsedWithSkip_ShouldSkip()
+    {
+        await Task.Delay(10_000);
+        true.Should().BeFalse("this assert will always fail, but the test should be skipped so it doesn't matter");
+    }
 }

--- a/test/FlakyTest.XUnit.Tests.Integration/MaybeFixedTheoryTestCaseTests.cs
+++ b/test/FlakyTest.XUnit.Tests.Integration/MaybeFixedTheoryTestCaseTests.cs
@@ -79,7 +79,7 @@ public class MaybeFixedTheoryTestCaseTests
             .Should()
             .BeLessOrEqualTo(CustomRetries);
     }
-    
+
     [MaybeFixedTheory(Skip = "skipping")]
     [InlineData(true, Skip = "skipping")]
     public async Task WhenUsedWithSkipTheory_ShouldSkip(bool value)
@@ -87,7 +87,7 @@ public class MaybeFixedTheoryTestCaseTests
         await Task.Delay(10_000);
         value.Should().BeFalse("this assert will always fail, but the test should be skipped so it doesn't matter");
     }
-    
+
     [MaybeFixedTheory]
     [InlineData(true, Skip = "skipping")]
     public async Task WhenUsedWithSkipInlineData_ShouldSkip(bool value)

--- a/test/FlakyTest.XUnit.Tests.Integration/MaybeFixedTheoryTestCaseTests.cs
+++ b/test/FlakyTest.XUnit.Tests.Integration/MaybeFixedTheoryTestCaseTests.cs
@@ -79,4 +79,20 @@ public class MaybeFixedTheoryTestCaseTests
             .Should()
             .BeLessOrEqualTo(CustomRetries);
     }
+    
+    [MaybeFixedTheory(Skip = "skipping")]
+    [InlineData(true, Skip = "skipping")]
+    public async Task WhenUsedWithSkipTheory_ShouldSkip(bool value)
+    {
+        await Task.Delay(10_000);
+        value.Should().BeFalse("this assert will always fail, but the test should be skipped so it doesn't matter");
+    }
+    
+    [MaybeFixedTheory]
+    [InlineData(true, Skip = "skipping")]
+    public async Task WhenUsedWithSkipInlineData_ShouldSkip(bool value)
+    {
+        await Task.Delay(10_000);
+        value.Should().BeFalse("this assert will always fail, but the test should be skipped so it doesn't matter");
+    }
 }


### PR DESCRIPTION
misses from #8 