### PR TITLE
Downgrading the XUnit version being used in the src project

### DIFF
--- a/src/FlakyTest.XUnit/FlakyTest.XUnit.csproj
+++ b/src/FlakyTest.XUnit/FlakyTest.XUnit.csproj
@@ -35,7 +35,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="xunit.core" Version="2.4.2" />
+    <PackageReference Include="xunit.core" Version="2.4.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Description

* Was having issues with some of the XUnit assert changes (seemingly) introduced in the most recent version of XUnit
* Looks like targeting the lower version of XUnit shouldn't impact the functionality of this package, and will be more accessible to additional consumers.

Fixes # (issue number)

## Type of Change

Use an `x` in between the `[ ]` for each line applicable to the type of change for this PR

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation
- [x] Code improvement
- [ ] Breaking change - if a public API changes, or any change that **_DOES_** or **_MAY_** require a major revision to the NuGet package version due to [semver](https://semver.org/).
- [ ] Unit tests
- [ ] Code samples
- [ ] Added your repository URL to the readme because you make use of this super cool package! ;)
- [x] Other

Changes the XUnit dependency from 2.4.2 to 2.4.0

## Checklist

- [x] Read the https://github.com/Kritner-Blogs/FlakyTest.XUnit/blob/main/CONTRIBUTING.md
- [x] Ran unit tests and ensured they passed
- [ ] Added unit tests where applicable
- [ ] Referenced an issue where applicable
- [x] Ran `dotnet-format` locally
