### PR TITLE
Fixing a copy/paste issue with XML documentation around the `MaybeFix…

### DIFF
--- a/src/FlakyTest.XUnit/Attributes/MaybeFixedFactAttribute.cs
+++ b/src/FlakyTest.XUnit/Attributes/MaybeFixedFactAttribute.cs
@@ -22,7 +22,10 @@ public class MaybeFixedFactAttribute : FactAttribute, IMaybeFixedAttribute
     /// <summary>
     /// Constructor
     /// </summary>
-    /// <param name="retriesBeforeDeemingNoLongerFlaky">The number of retries prior to marking a test as failed.</param>
+    /// <param name="retriesBeforeDeemingNoLongerFlaky">
+    /// The number of times to run the test.  Each attempt must pass for the test to be overall considered a 
+    /// "passing" (or no longer flaky) test.
+    /// </param>
     public MaybeFixedFactAttribute(
         int retriesBeforeDeemingNoLongerFlaky = IMaybeFixedAttribute.DefaultRetriesBeforeDeemingNoLongerFlaky)
     {

--- a/src/FlakyTest.XUnit/Attributes/MaybeFixedTheoryAttribute.cs
+++ b/src/FlakyTest.XUnit/Attributes/MaybeFixedTheoryAttribute.cs
@@ -22,7 +22,10 @@ public class MaybeFixedTheoryAttribute : TheoryAttribute, IMaybeFixedAttribute
     /// <summary>
     /// Constructor
     /// </summary>
-    /// <param name="retriesBeforeDeemingNoLongerFlaky">The number of retries prior to marking a test as failed.</param>
+    /// <param name="retriesBeforeDeemingNoLongerFlaky">
+    /// The number of times to run the test.  Each attempt must pass for the test to be overall considered a 
+    /// "passing" (or no longer flaky) test.
+    /// </param>
     public MaybeFixedTheoryAttribute(
         int retriesBeforeDeemingNoLongerFlaky = IMaybeFixedAttribute.DefaultRetriesBeforeDeemingNoLongerFlaky)
     {


### PR DESCRIPTION
Fixing a copy/paste issue with XML documentation around the `MaybeFixed` attributes

# Description

Parameter XML in constructors was incorrect for the `MaybeFixedFact` and `MaybeFixedTheory` attributes.

## Type of Change

Use an `x` in between the `[ ]` for each line applicable to the type of change for this PR

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation
- [ ] Code improvement
- [ ] Breaking change - if a public API changes, or any change that **_DOES_** or **_MAY_** require a major revision to the NuGet package version due to [semver](https://semver.org/).
- [ ] Unit tests
- [ ] Code samples
- [ ] Added your repository URL to the readme because you make use of this super cool package! ;)
- [ ] Other

Please describe if other

## Checklist

- [x] Read the https://github.com/Kritner-Blogs/FlakyTest.XUnit/blob/main/CONTRIBUTING.md
- [x] Ran unit tests and ensured they passed
- [ ] Added unit tests where applicable
- [ ] Referenced an issue where applicable
- [x] Ran `dotnet-format` locally
