### PR TITLE
Adds overall test case disposition, additional tests

### DIFF
--- a/src/FlakyTest.XUnit/Enums/FlakyDisposition.cs
+++ b/src/FlakyTest.XUnit/Enums/FlakyDisposition.cs
@@ -1,0 +1,32 @@
+﻿namespace FlakyTest.XUnit.Enums;
+
+/// <summary>
+/// An disposition that is updated on test cases.
+/// </summary>
+public enum FlakyDisposition
+{
+    /// <summary>
+    /// Test has not yet started.
+    /// </summary>
+    NotStarted,
+    
+    /// <summary>
+    /// Test is running.
+    /// </summary>
+    Running,
+    
+    /// <summary>
+    /// The test was cancelled.
+    /// </summary>
+    Cancelled,
+    
+    /// <summary>
+    /// The test failed.
+    /// </summary>
+    Fail,
+    
+    /// <summary>
+    /// The test was successful.
+    /// </summary>
+    Success
+}

--- a/src/FlakyTest.XUnit/Enums/FlakyDisposition.cs
+++ b/src/FlakyTest.XUnit/Enums/FlakyDisposition.cs
@@ -9,22 +9,22 @@ public enum FlakyDisposition
     /// Test has not yet started.
     /// </summary>
     NotStarted,
-    
+
     /// <summary>
     /// Test is running.
     /// </summary>
     Running,
-    
+
     /// <summary>
     /// The test was cancelled.
     /// </summary>
     Cancelled,
-    
+
     /// <summary>
     /// The test failed.
     /// </summary>
     Fail,
-    
+
     /// <summary>
     /// The test was successful.
     /// </summary>

--- a/src/FlakyTest.XUnit/Interfaces/IFlakyTestCase.cs
+++ b/src/FlakyTest.XUnit/Interfaces/IFlakyTestCase.cs
@@ -1,4 +1,5 @@
-﻿using Xunit.Sdk;
+﻿using FlakyTest.XUnit.Enums;
+using Xunit.Sdk;
 
 namespace FlakyTest.XUnit.Interfaces;
 
@@ -11,4 +12,9 @@ public interface IFlakyTestCase : IXunitTestCase
     /// The maximum number of retries before deeming a test case as a failed test.
     /// </summary>
     int RetriesBeforeFail { get; }
+    
+    /// <summary>
+    /// The status of the test.
+    /// </summary>
+    FlakyDisposition FlakyDisposition { get; }
 }

--- a/src/FlakyTest.XUnit/Interfaces/IFlakyTestCase.cs
+++ b/src/FlakyTest.XUnit/Interfaces/IFlakyTestCase.cs
@@ -12,7 +12,7 @@ public interface IFlakyTestCase : IXunitTestCase
     /// The maximum number of retries before deeming a test case as a failed test.
     /// </summary>
     int RetriesBeforeFail { get; }
-    
+
     /// <summary>
     /// The status of the test.
     /// </summary>

--- a/src/FlakyTest.XUnit/Interfaces/IMaybeFixedTestCase.cs
+++ b/src/FlakyTest.XUnit/Interfaces/IMaybeFixedTestCase.cs
@@ -1,4 +1,5 @@
-﻿using Xunit.Sdk;
+﻿using FlakyTest.XUnit.Enums;
+using Xunit.Sdk;
 
 namespace FlakyTest.XUnit.Interfaces;
 
@@ -11,4 +12,9 @@ public interface IMaybeFixedTestCase : IXunitTestCase
     /// The number of successful runs of the test to "pass" and consider no longer flaky.
     /// </summary>
     int RetriesBeforeDeemingNoLongerFlaky { get; }
+    
+    /// <summary>
+    /// The status of the test.
+    /// </summary>
+    FlakyDisposition FlakyDisposition { get; }
 }

--- a/src/FlakyTest.XUnit/Interfaces/IMaybeFixedTestCase.cs
+++ b/src/FlakyTest.XUnit/Interfaces/IMaybeFixedTestCase.cs
@@ -12,7 +12,7 @@ public interface IMaybeFixedTestCase : IXunitTestCase
     /// The number of successful runs of the test to "pass" and consider no longer flaky.
     /// </summary>
     int RetriesBeforeDeemingNoLongerFlaky { get; }
-    
+
     /// <summary>
     /// The status of the test.
     /// </summary>

--- a/src/FlakyTest.XUnit/Models/FlakyTestCase.cs
+++ b/src/FlakyTest.XUnit/Models/FlakyTestCase.cs
@@ -19,7 +19,7 @@ public class FlakyTestCase : XunitTestCase, IFlakyTestCase
     /// Message template string for running a test attempt
     /// </summary>
     public const string MessageTemplateRunningTestAttemptOf = "Running test '{0}'.  Attempt {1} of {2}";
-    
+
     /// <summary>
     /// Message template string for a failed test case 
     /// </summary>
@@ -55,10 +55,10 @@ public class FlakyTestCase : XunitTestCase, IFlakyTestCase
 
     /// <inheritdoc />
     public override async Task<RunSummary> RunAsync(
-        IMessageSink diagnosticMessageSink, 
+        IMessageSink diagnosticMessageSink,
         IMessageBus messageBus,
-        object[] constructorArguments, 
-        ExceptionAggregator aggregator, 
+        object[] constructorArguments,
+        ExceptionAggregator aggregator,
         CancellationTokenSource cancellationTokenSource)
     {
         return await RunAsync(this, diagnosticMessageSink, messageBus, cancellationTokenSource,
@@ -86,7 +86,7 @@ public class FlakyTestCase : XunitTestCase, IFlakyTestCase
     /// </summary>
     protected virtual Func<IMessageBus, Task<RunSummary>> RunFunc(
         object[] constructorArguments,
-        ExceptionAggregator aggregator, 
+        ExceptionAggregator aggregator,
         CancellationTokenSource cancellationTokenSource)
     {
         return bus => new XunitTestCaseRunner(this, DisplayName, SkipReason, constructorArguments,

--- a/src/FlakyTest.XUnit/Models/MaybeFixedTestCase.cs
+++ b/src/FlakyTest.XUnit/Models/MaybeFixedTestCase.cs
@@ -45,10 +45,10 @@ public class MaybeFixedTestCase : XunitTestCase, IMaybeFixedTestCase
 
     /// <inheritdoc />
     public override async Task<RunSummary> RunAsync(
-        IMessageSink diagnosticMessageSink, 
+        IMessageSink diagnosticMessageSink,
         IMessageBus messageBus,
-        object[] constructorArguments, 
-        ExceptionAggregator aggregator, 
+        object[] constructorArguments,
+        ExceptionAggregator aggregator,
         CancellationTokenSource cancellationTokenSource)
     {
         return await RunAsync(this, diagnosticMessageSink, messageBus, cancellationTokenSource,
@@ -70,13 +70,13 @@ public class MaybeFixedTestCase : XunitTestCase, IMaybeFixedTestCase
 
         RetriesBeforeDeemingNoLongerFlaky = data.GetValue<int>(nameof(RetriesBeforeDeemingNoLongerFlaky));
     }
-    
+
     /// <summary>
     /// Initialize runner and run
     /// </summary>
     protected virtual Func<IMessageBus, Task<RunSummary>> RunFunc(
         object[] constructorArguments,
-        ExceptionAggregator aggregator, 
+        ExceptionAggregator aggregator,
         CancellationTokenSource cancellationTokenSource)
     {
         return bus => new XunitTestCaseRunner(this, DisplayName, SkipReason, constructorArguments,

--- a/src/FlakyTest.XUnit/Models/MaybeFixedTestCase.cs
+++ b/src/FlakyTest.XUnit/Models/MaybeFixedTestCase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
+using FlakyTest.XUnit.Enums;
 using FlakyTest.XUnit.Interfaces;
 using FlakyTest.XUnit.Services;
 using Xunit.Abstractions;
@@ -40,13 +41,18 @@ public class MaybeFixedTestCase : XunitTestCase, IMaybeFixedTestCase
     public int RetriesBeforeDeemingNoLongerFlaky { get; private set; }
 
     /// <inheritdoc />
-    public override async Task<RunSummary> RunAsync(IMessageSink diagnosticMessageSink, IMessageBus messageBus,
-        object[] constructorArguments, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource)
+    public FlakyDisposition FlakyDisposition { get; private set; }
+
+    /// <inheritdoc />
+    public override async Task<RunSummary> RunAsync(
+        IMessageSink diagnosticMessageSink, 
+        IMessageBus messageBus,
+        object[] constructorArguments, 
+        ExceptionAggregator aggregator, 
+        CancellationTokenSource cancellationTokenSource)
     {
         return await RunAsync(this, diagnosticMessageSink, messageBus, cancellationTokenSource,
-            funcRun: bus => new XunitTestCaseRunner(this, DisplayName, SkipReason, constructorArguments,
-                    TestMethodArguments, bus, aggregator, cancellationTokenSource)
-                .RunAsync());
+            funcRun: RunFunc(constructorArguments, aggregator, cancellationTokenSource));
     }
 
     /// <inheritdoc />
@@ -64,14 +70,28 @@ public class MaybeFixedTestCase : XunitTestCase, IMaybeFixedTestCase
 
         RetriesBeforeDeemingNoLongerFlaky = data.GetValue<int>(nameof(RetriesBeforeDeemingNoLongerFlaky));
     }
+    
+    /// <summary>
+    /// Initialize runner and run
+    /// </summary>
+    protected virtual Func<IMessageBus, Task<RunSummary>> RunFunc(
+        object[] constructorArguments,
+        ExceptionAggregator aggregator, 
+        CancellationTokenSource cancellationTokenSource)
+    {
+        return bus => new XunitTestCaseRunner(this, DisplayName, SkipReason, constructorArguments,
+                TestMethodArguments, bus, aggregator, cancellationTokenSource)
+            .RunAsync();
+    }
 
-    private static async Task<RunSummary> RunAsync(
+    private async Task<RunSummary> RunAsync(
         IMaybeFixedTestCase testCase,
         IMessageSink diagnosticMessageSink,
         IMessageBus messageBus,
         CancellationTokenSource cancellationTokenSource,
         Func<IMessageBus, Task<RunSummary>> funcRun)
     {
+        FlakyDisposition = FlakyDisposition.Running;
         var attempt = 0;
         while (!cancellationTokenSource.IsCancellationRequested)
         {
@@ -83,7 +103,7 @@ public class MaybeFixedTestCase : XunitTestCase, IMaybeFixedTestCase
 
             RunSummary summary = await funcRun(flakyTestMessageBus);
 
-            if (summary.Failed > 0 || attempt == testCase.RetriesBeforeDeemingNoLongerFlaky - 1)
+            if (summary.Failed > 0 || attempt >= testCase.RetriesBeforeDeemingNoLongerFlaky - 1)
             {
                 if (summary.Failed > 0)
                 {
@@ -92,6 +112,7 @@ public class MaybeFixedTestCase : XunitTestCase, IMaybeFixedTestCase
                         testCase.DisplayName, attempt));
                 }
 
+                FlakyDisposition = summary.Failed > 0 ? FlakyDisposition.Fail : FlakyDisposition.Success;
                 flakyTestMessageBus.Flush();
                 return summary;
             }
@@ -103,13 +124,14 @@ public class MaybeFixedTestCase : XunitTestCase, IMaybeFixedTestCase
         }
 
         // Task was cancelled.
+        FlakyDisposition = FlakyDisposition.Cancelled;
         diagnosticMessageSink.OnMessage(new DiagnosticMessage(
             "The test '{0}' run attempt was cancelled.",
             testCase.DisplayName));
 
         return new RunSummary()
         {
-            Failed = 0,
+            Skipped = 1,
             Total = 1,
         };
     }

--- a/test/FlakyTest.XUnit.Tests/Fakes/DelayedFlakyTestCase.cs
+++ b/test/FlakyTest.XUnit.Tests/Fakes/DelayedFlakyTestCase.cs
@@ -1,0 +1,37 @@
+﻿using FlakyTest.XUnit.Models;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace FlakyTest.XUnit.Tests.Fakes;
+
+/// <summary>
+/// Fake flaky test case that returns a fail response after an amount of time.
+/// </summary>
+public class DelayedFlakyTestCase : FlakyTestCase
+{
+    [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
+    public DelayedFlakyTestCase()
+    {
+    }
+
+    public DelayedFlakyTestCase(
+        IMessageSink diagnosticMessageSink,
+        TestMethodDisplay defaultMethodDisplay,
+        TestMethodDisplayOptions defaultMethodDisplayOptions,
+        ITestMethod testMethod,
+        int retriesBeforeFail,
+        object[]? testMethodArguments = null)
+        : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, retriesBeforeFail, testMethodArguments)
+    {
+    }
+        
+    protected override Func<IMessageBus, Task<RunSummary>> RunFunc(object[] constructorArguments, ExceptionAggregator aggregator,
+        CancellationTokenSource cancellationTokenSource)
+    {
+        return async bus =>
+        {
+            await Task.Delay(10_000);
+            return new RunSummary() {Total = 1, Failed = 1};
+        };
+    }
+}

--- a/test/FlakyTest.XUnit.Tests/Fakes/DelayedFlakyTestCase.cs
+++ b/test/FlakyTest.XUnit.Tests/Fakes/DelayedFlakyTestCase.cs
@@ -24,14 +24,14 @@ public class DelayedFlakyTestCase : FlakyTestCase
         : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, retriesBeforeFail, testMethodArguments)
     {
     }
-        
+
     protected override Func<IMessageBus, Task<RunSummary>> RunFunc(object[] constructorArguments, ExceptionAggregator aggregator,
         CancellationTokenSource cancellationTokenSource)
     {
         return async bus =>
         {
             await Task.Delay(10_000);
-            return new RunSummary() {Total = 1, Failed = 1};
+            return new RunSummary() { Total = 1, Failed = 1 };
         };
     }
 }

--- a/test/FlakyTest.XUnit.Tests/Fakes/DelayedMaybeFixedTestCase.cs
+++ b/test/FlakyTest.XUnit.Tests/Fakes/DelayedMaybeFixedTestCase.cs
@@ -24,14 +24,14 @@ public class DelayedMaybeFixedTestCase : MaybeFixedTestCase
         : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, retriesBeforeFail, testMethodArguments)
     {
     }
-        
+
     protected override Func<IMessageBus, Task<RunSummary>> RunFunc(object[] constructorArguments, ExceptionAggregator aggregator,
         CancellationTokenSource cancellationTokenSource)
     {
         return async bus =>
         {
             await Task.Delay(10_000);
-            return new RunSummary() {Total = 1, Failed = 1};
+            return new RunSummary() { Total = 1, Failed = 1 };
         };
     }
 }

--- a/test/FlakyTest.XUnit.Tests/Fakes/DelayedMaybeFixedTestCase.cs
+++ b/test/FlakyTest.XUnit.Tests/Fakes/DelayedMaybeFixedTestCase.cs
@@ -1,0 +1,37 @@
+﻿using FlakyTest.XUnit.Models;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace FlakyTest.XUnit.Tests.Fakes;
+
+/// <summary>
+/// Fake maybe fixed test case that returns a fail response after an amount of time.
+/// </summary>
+public class DelayedMaybeFixedTestCase : MaybeFixedTestCase
+{
+    [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
+    public DelayedMaybeFixedTestCase()
+    {
+    }
+
+    public DelayedMaybeFixedTestCase(
+        IMessageSink diagnosticMessageSink,
+        TestMethodDisplay defaultMethodDisplay,
+        TestMethodDisplayOptions defaultMethodDisplayOptions,
+        ITestMethod testMethod,
+        int retriesBeforeFail,
+        object[]? testMethodArguments = null)
+        : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, retriesBeforeFail, testMethodArguments)
+    {
+    }
+        
+    protected override Func<IMessageBus, Task<RunSummary>> RunFunc(object[] constructorArguments, ExceptionAggregator aggregator,
+        CancellationTokenSource cancellationTokenSource)
+    {
+        return async bus =>
+        {
+            await Task.Delay(10_000);
+            return new RunSummary() {Total = 1, Failed = 1};
+        };
+    }
+}

--- a/test/FlakyTest.XUnit.Tests/Fakes/FailFlakyTestCase.cs
+++ b/test/FlakyTest.XUnit.Tests/Fakes/FailFlakyTestCase.cs
@@ -1,0 +1,33 @@
+﻿using FlakyTest.XUnit.Models;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace FlakyTest.XUnit.Tests.Fakes;
+
+/// <summary>
+/// Fake flaky test case that always reports fail
+/// </summary>
+public class FailFlakyTestCase : FlakyTestCase
+{
+    [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
+    public FailFlakyTestCase()
+    {
+    }
+
+    public FailFlakyTestCase(
+        IMessageSink diagnosticMessageSink,
+        TestMethodDisplay defaultMethodDisplay,
+        TestMethodDisplayOptions defaultMethodDisplayOptions,
+        ITestMethod testMethod,
+        int retriesBeforeFail,
+        object[]? testMethodArguments = null)
+        : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, retriesBeforeFail, testMethodArguments)
+    {
+    }
+        
+    protected override Func<IMessageBus, Task<RunSummary>> RunFunc(object[] constructorArguments, ExceptionAggregator aggregator,
+        CancellationTokenSource cancellationTokenSource)
+    {
+        return bus => Task.FromResult(new RunSummary() {Total = 1, Failed = 1});
+    }
+}

--- a/test/FlakyTest.XUnit.Tests/Fakes/FailFlakyTestCase.cs
+++ b/test/FlakyTest.XUnit.Tests/Fakes/FailFlakyTestCase.cs
@@ -24,10 +24,10 @@ public class FailFlakyTestCase : FlakyTestCase
         : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, retriesBeforeFail, testMethodArguments)
     {
     }
-        
+
     protected override Func<IMessageBus, Task<RunSummary>> RunFunc(object[] constructorArguments, ExceptionAggregator aggregator,
         CancellationTokenSource cancellationTokenSource)
     {
-        return bus => Task.FromResult(new RunSummary() {Total = 1, Failed = 1});
+        return bus => Task.FromResult(new RunSummary() { Total = 1, Failed = 1 });
     }
 }

--- a/test/FlakyTest.XUnit.Tests/Fakes/FailMaybeFixedTestCase.cs
+++ b/test/FlakyTest.XUnit.Tests/Fakes/FailMaybeFixedTestCase.cs
@@ -1,0 +1,33 @@
+﻿using FlakyTest.XUnit.Models;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace FlakyTest.XUnit.Tests.Fakes;
+
+/// <summary>
+/// Fake MaybeFixed test case that always reports fail
+/// </summary>
+public class FailMaybeFixedTestCase : MaybeFixedTestCase
+{
+    [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
+    public FailMaybeFixedTestCase()
+    {
+    }
+
+    public FailMaybeFixedTestCase(
+        IMessageSink diagnosticMessageSink,
+        TestMethodDisplay defaultMethodDisplay,
+        TestMethodDisplayOptions defaultMethodDisplayOptions,
+        ITestMethod testMethod,
+        int retriesBeforeFail,
+        object[]? testMethodArguments = null)
+        : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, retriesBeforeFail, testMethodArguments)
+    {
+    }
+        
+    protected override Func<IMessageBus, Task<RunSummary>> RunFunc(object[] constructorArguments, ExceptionAggregator aggregator,
+        CancellationTokenSource cancellationTokenSource)
+    {
+        return bus => Task.FromResult(new RunSummary() {Total = 1, Failed = 1});
+    }
+}

--- a/test/FlakyTest.XUnit.Tests/Fakes/FailMaybeFixedTestCase.cs
+++ b/test/FlakyTest.XUnit.Tests/Fakes/FailMaybeFixedTestCase.cs
@@ -24,10 +24,10 @@ public class FailMaybeFixedTestCase : MaybeFixedTestCase
         : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, retriesBeforeFail, testMethodArguments)
     {
     }
-        
+
     protected override Func<IMessageBus, Task<RunSummary>> RunFunc(object[] constructorArguments, ExceptionAggregator aggregator,
         CancellationTokenSource cancellationTokenSource)
     {
-        return bus => Task.FromResult(new RunSummary() {Total = 1, Failed = 1});
+        return bus => Task.FromResult(new RunSummary() { Total = 1, Failed = 1 });
     }
 }

--- a/test/FlakyTest.XUnit.Tests/Fakes/SuccessFlakyTestCase.cs
+++ b/test/FlakyTest.XUnit.Tests/Fakes/SuccessFlakyTestCase.cs
@@ -24,10 +24,10 @@ public class SuccessFlakyTestCase : FlakyTestCase
         : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, retriesBeforeFail, testMethodArguments)
     {
     }
-        
+
     protected override Func<IMessageBus, Task<RunSummary>> RunFunc(object[] constructorArguments, ExceptionAggregator aggregator,
         CancellationTokenSource cancellationTokenSource)
     {
-        return bus => Task.FromResult(new RunSummary() {Total = 1});
+        return bus => Task.FromResult(new RunSummary() { Total = 1 });
     }
 }

--- a/test/FlakyTest.XUnit.Tests/Fakes/SuccessFlakyTestCase.cs
+++ b/test/FlakyTest.XUnit.Tests/Fakes/SuccessFlakyTestCase.cs
@@ -1,0 +1,33 @@
+﻿using FlakyTest.XUnit.Models;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace FlakyTest.XUnit.Tests.Fakes;
+
+/// <summary>
+/// Fake flaky test case that always reports success
+/// </summary>
+public class SuccessFlakyTestCase : FlakyTestCase
+{
+    [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
+    public SuccessFlakyTestCase()
+    {
+    }
+
+    public SuccessFlakyTestCase(
+        IMessageSink diagnosticMessageSink,
+        TestMethodDisplay defaultMethodDisplay,
+        TestMethodDisplayOptions defaultMethodDisplayOptions,
+        ITestMethod testMethod,
+        int retriesBeforeFail,
+        object[]? testMethodArguments = null)
+        : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, retriesBeforeFail, testMethodArguments)
+    {
+    }
+        
+    protected override Func<IMessageBus, Task<RunSummary>> RunFunc(object[] constructorArguments, ExceptionAggregator aggregator,
+        CancellationTokenSource cancellationTokenSource)
+    {
+        return bus => Task.FromResult(new RunSummary() {Total = 1});
+    }
+}

--- a/test/FlakyTest.XUnit.Tests/Fakes/SuccessMaybeFixedTestCase.cs
+++ b/test/FlakyTest.XUnit.Tests/Fakes/SuccessMaybeFixedTestCase.cs
@@ -24,10 +24,10 @@ public class SuccessMaybeFixedTestCase : MaybeFixedTestCase
         : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, retriesBeforeFail, testMethodArguments)
     {
     }
-        
+
     protected override Func<IMessageBus, Task<RunSummary>> RunFunc(object[] constructorArguments, ExceptionAggregator aggregator,
         CancellationTokenSource cancellationTokenSource)
     {
-        return bus => Task.FromResult(new RunSummary() {Total = 1});
+        return bus => Task.FromResult(new RunSummary() { Total = 1 });
     }
 }

--- a/test/FlakyTest.XUnit.Tests/Fakes/SuccessMaybeFixedTestCase.cs
+++ b/test/FlakyTest.XUnit.Tests/Fakes/SuccessMaybeFixedTestCase.cs
@@ -1,0 +1,33 @@
+﻿using FlakyTest.XUnit.Models;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace FlakyTest.XUnit.Tests.Fakes;
+
+/// <summary>
+/// Fake MaybeFixed test case that always reports success
+/// </summary>
+public class SuccessMaybeFixedTestCase : MaybeFixedTestCase
+{
+    [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
+    public SuccessMaybeFixedTestCase()
+    {
+    }
+
+    public SuccessMaybeFixedTestCase(
+        IMessageSink diagnosticMessageSink,
+        TestMethodDisplay defaultMethodDisplay,
+        TestMethodDisplayOptions defaultMethodDisplayOptions,
+        ITestMethod testMethod,
+        int retriesBeforeFail,
+        object[]? testMethodArguments = null)
+        : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, retriesBeforeFail, testMethodArguments)
+    {
+    }
+        
+    protected override Func<IMessageBus, Task<RunSummary>> RunFunc(object[] constructorArguments, ExceptionAggregator aggregator,
+        CancellationTokenSource cancellationTokenSource)
+    {
+        return bus => Task.FromResult(new RunSummary() {Total = 1});
+    }
+}

--- a/test/FlakyTest.XUnit.Tests/Fakes/TestableTestCaseRunner.cs
+++ b/test/FlakyTest.XUnit.Tests/Fakes/TestableTestCaseRunner.cs
@@ -1,0 +1,36 @@
+﻿using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace FlakyTest.XUnit.Tests.Fakes;
+
+/// <summary>
+/// An implementation of <see cref="TestCaseRunner{TTestCase}"/> to support expected disposition tests.
+/// </summary>
+public class TestableTestCaseRunner<TErrorTestCase> : TestCaseRunner<TErrorTestCase>
+    where TErrorTestCase : XunitTestCase
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TestableTestCaseRunner"/> class.
+    /// </summary>
+    /// <param name="testCase">The test case that the lambda represents.</param>
+    /// <param name="messageSink">The message sink.</param>
+    /// <param name="messageBus">The message bus to report run status to.</param>
+    /// <param name="aggregator">The exception aggregator used to run code and collect exceptions.</param>
+    /// <param name="cancellationTokenSource">The task cancellation token source, used to cancel the test run.</param>
+    public TestableTestCaseRunner(TErrorTestCase testCase,
+        IMessageSink messageSink,
+        IMessageBus messageBus,
+        ExceptionAggregator aggregator,
+        CancellationTokenSource cancellationTokenSource)
+        : base(testCase, messageBus, aggregator, cancellationTokenSource)
+    {
+        MessageSink = messageSink;
+    }
+
+    private IMessageSink MessageSink { get; }
+
+    protected override async Task<RunSummary> RunTestAsync()
+    {
+        return await TestCase.RunAsync(MessageSink, MessageBus, null, Aggregator, CancellationTokenSource);
+    }
+}

--- a/test/FlakyTest.XUnit.Tests/FlakyTest.XUnit.Tests.csproj
+++ b/test/FlakyTest.XUnit.Tests/FlakyTest.XUnit.Tests.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="FluentAssertions" Version="6.8.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="NSubstitute" Version="4.4.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>

--- a/test/FlakyTest.XUnit.Tests/Unit/Models/FlakyTestCaseTests.cs
+++ b/test/FlakyTest.XUnit.Tests/Unit/Models/FlakyTestCaseTests.cs
@@ -1,0 +1,69 @@
+﻿using FlakyTest.XUnit.Models;
+using Moq;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace FlakyTest.XUnit.Tests.Unit.Models;
+
+/// <summary>
+/// Unit tests against <see cref="FlakyTestCase"/>
+/// </summary>
+public class FlakyTestCaseTests
+{
+    private readonly Mock<IXunitSerializationInfo> _xunitSerializationInfo = new();
+    private readonly ITestMethod _testMethod = Mocks.TestMethod("MockType", "MockMethod");
+
+    public FlakyTestCaseTests()
+    {
+        _xunitSerializationInfo
+            .Setup(s => s.GetValue<string>("DefaultMethodDisplay"))
+            .Returns("Method");
+        _xunitSerializationInfo
+            .Setup(s => s.GetValue<string>("DefaultMethodDisplayOptions"))
+            .Returns("None");
+        _xunitSerializationInfo
+            .Setup(s => s.GetValue<ITestMethod>("TestMethod"))
+            .Returns(_testMethod);
+    }
+
+    [Theory]
+    [InlineData(5)]
+    [InlineData(42)]
+    public void ShouldSerializeWithExpectedCalls(int retriesBeforeFail)
+    {
+        var sut = GetSystemUnderTest(retriesBeforeFail);
+        
+        sut.Serialize(_xunitSerializationInfo.Object);
+
+        _xunitSerializationInfo
+            .Verify(v =>
+                    v.AddValue(nameof(FlakyTestCase.RetriesBeforeFail), retriesBeforeFail, null),
+                Times.Once);
+    }
+
+    [Fact]
+    public void ShouldDeserializeWithExpectedCalls()
+    {
+        var sut = GetSystemUnderTest(5);
+
+        sut.Deserialize(_xunitSerializationInfo.Object);
+
+        _xunitSerializationInfo
+            .Verify(v =>
+                v.GetValue<int>(nameof(FlakyTestCase.RetriesBeforeFail)), Times.Once);
+    }
+    
+    private FlakyTestCase GetSystemUnderTest(int retriesBeforeFail)
+    {
+        var sut = new FlakyTestCase(
+            new NullMessageSink(),
+            TestMethodDisplay.Method,
+            TestMethodDisplayOptions.All,
+            _testMethod,
+            retriesBeforeFail,
+            null);
+
+        return sut;
+    }
+}

--- a/test/FlakyTest.XUnit.Tests/Unit/Models/FlakyTestCaseTests.cs
+++ b/test/FlakyTest.XUnit.Tests/Unit/Models/FlakyTestCaseTests.cs
@@ -41,7 +41,7 @@ public class FlakyTestCaseTests
     public void ShouldSerializeWithExpectedCalls(int retriesBeforeFail)
     {
         var sut = GetSystemUnderTest(retriesBeforeFail);
-        
+
         sut.Serialize(_xunitSerializationInfo.Object);
 
         _xunitSerializationInfo
@@ -70,7 +70,7 @@ public class FlakyTestCaseTests
             .Setup(s => s.QueueMessage(It.IsAny<IMessageSinkMessage>()))
             .Returns(true);
         var messageSink = new Mock<IMessageSink>();
-        
+
         var sut = GetFailTestCase(1, messageSink.Object);
         var runner = new TestableTestCaseRunner<FlakyTestCase>(
             sut,
@@ -86,7 +86,7 @@ public class FlakyTestCaseTests
 
         sut.FlakyDisposition.Should().Be(FlakyDisposition.Fail);
     }
-    
+
     [Fact]
     public async Task ShouldRunAndReportSuccessToDispositionProperty()
     {
@@ -95,7 +95,7 @@ public class FlakyTestCaseTests
             .Setup(s => s.QueueMessage(It.IsAny<IMessageSinkMessage>()))
             .Returns(true);
         var messageSink = new Mock<IMessageSink>();
-        
+
         var sut = GetSuccessTestCase(1, messageSink.Object);
         var runner = new TestableTestCaseRunner<FlakyTestCase>(
             sut,
@@ -111,7 +111,7 @@ public class FlakyTestCaseTests
 
         sut.FlakyDisposition.Should().Be(FlakyDisposition.Success);
     }
-    
+
     [Fact]
     public async Task ShouldRunAndReportCancelledToDispositionProperty()
     {
@@ -138,9 +138,9 @@ public class FlakyTestCaseTests
 
         sut.FlakyDisposition.Should().Be(FlakyDisposition.Cancelled);
     }
-    
+
     private FlakyTestCase GetSystemUnderTest(
-        int retriesBeforeFail = IFlakyAttribute.DefaultRetriesBeforeFail, 
+        int retriesBeforeFail = IFlakyAttribute.DefaultRetriesBeforeFail,
         IMessageSink? messageSink = null)
     {
         return new FlakyTestCase(
@@ -164,7 +164,7 @@ public class FlakyTestCaseTests
             retriesBeforeFail,
             null);
     }
-    
+
     private SuccessFlakyTestCase GetSuccessTestCase(
         int retriesBeforeFail = IFlakyAttribute.DefaultRetriesBeforeFail,
         IMessageSink? messageSink = null)
@@ -177,7 +177,7 @@ public class FlakyTestCaseTests
             retriesBeforeFail,
             null);
     }
-    
+
     private DelayedFlakyTestCase GetDelayedTestCase(
         int retriesBeforeFail = IFlakyAttribute.DefaultRetriesBeforeFail,
         IMessageSink? messageSink = null)

--- a/test/FlakyTest.XUnit.Tests/Unit/Models/MaybeFixedTestCaseTests.cs
+++ b/test/FlakyTest.XUnit.Tests/Unit/Models/MaybeFixedTestCaseTests.cs
@@ -7,7 +7,6 @@ using Moq;
 using Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;
-using DiagnosticMessage = Xunit.Sdk.DiagnosticMessage;
 using NullMessageSink = Xunit.Sdk.NullMessageSink;
 using TestMethodDisplay = Xunit.Sdk.TestMethodDisplay;
 using TestMethodDisplayOptions = Xunit.Sdk.TestMethodDisplayOptions;
@@ -15,14 +14,14 @@ using TestMethodDisplayOptions = Xunit.Sdk.TestMethodDisplayOptions;
 namespace FlakyTest.XUnit.Tests.Unit.Models;
 
 /// <summary>
-/// Unit tests against <see cref="FlakyTestCase"/>
+/// Unit tests against <see cref="MaybeFixedTestCase"/>
 /// </summary>
-public class FlakyTestCaseTests
+public class MaybeFixedTestCaseTests
 {
     private readonly Mock<IXunitSerializationInfo> _xunitSerializationInfo = new();
     private readonly ITestMethod _testMethod = Mocks.TestMethod("MockType", "MockMethod");
 
-    public FlakyTestCaseTests()
+    public MaybeFixedTestCaseTests()
     {
         _xunitSerializationInfo
             .Setup(s => s.GetValue<string>("DefaultMethodDisplay"))
@@ -46,7 +45,7 @@ public class FlakyTestCaseTests
 
         _xunitSerializationInfo
             .Verify(v =>
-                    v.AddValue(nameof(FlakyTestCase.RetriesBeforeFail), retriesBeforeFail, null),
+                    v.AddValue(nameof(MaybeFixedTestCase.RetriesBeforeDeemingNoLongerFlaky), retriesBeforeFail, null),
                 Times.Once);
     }
 
@@ -59,7 +58,7 @@ public class FlakyTestCaseTests
 
         _xunitSerializationInfo
             .Verify(v =>
-                v.GetValue<int>(nameof(FlakyTestCase.RetriesBeforeFail)), Times.Once);
+                v.GetValue<int>(nameof(MaybeFixedTestCase.RetriesBeforeDeemingNoLongerFlaky)), Times.Once);
     }
 
     [Fact]
@@ -72,7 +71,7 @@ public class FlakyTestCaseTests
         var messageSink = new Mock<IMessageSink>();
         
         var sut = GetFailTestCase(1, messageSink.Object);
-        var runner = new TestableTestCaseRunner<FlakyTestCase>(
+        var runner = new TestableTestCaseRunner<MaybeFixedTestCase>(
             sut,
             messageSink.Object,
             messageBus.Object,
@@ -97,7 +96,7 @@ public class FlakyTestCaseTests
         var messageSink = new Mock<IMessageSink>();
         
         var sut = GetSuccessTestCase(1, messageSink.Object);
-        var runner = new TestableTestCaseRunner<FlakyTestCase>(
+        var runner = new TestableTestCaseRunner<MaybeFixedTestCase>(
             sut,
             messageSink.Object,
             messageBus.Object,
@@ -123,7 +122,7 @@ public class FlakyTestCaseTests
 
         var tokenSource = new CancellationTokenSource();
         var sut = GetDelayedTestCase(1, messageSink.Object);
-        var runner = new TestableTestCaseRunner<FlakyTestCase>(
+        var runner = new TestableTestCaseRunner<MaybeFixedTestCase>(
             sut,
             messageSink.Object,
             messageBus.Object,
@@ -139,55 +138,55 @@ public class FlakyTestCaseTests
         sut.FlakyDisposition.Should().Be(FlakyDisposition.Cancelled);
     }
     
-    private FlakyTestCase GetSystemUnderTest(
-        int retriesBeforeFail = IFlakyAttribute.DefaultRetriesBeforeFail, 
+    private MaybeFixedTestCase GetSystemUnderTest(
+        int defaultRetriesBeforeDeemingNoLongerFlaky = IMaybeFixedAttribute.DefaultRetriesBeforeDeemingNoLongerFlaky, 
         IMessageSink? messageSink = null)
     {
-        return new FlakyTestCase(
+        return new MaybeFixedTestCase(
             messageSink ?? new NullMessageSink(),
             TestMethodDisplay.Method,
             TestMethodDisplayOptions.All,
             _testMethod,
-            retriesBeforeFail,
+            defaultRetriesBeforeDeemingNoLongerFlaky,
             null);
     }
 
-    private FailFlakyTestCase GetFailTestCase(
-        int retriesBeforeFail = IFlakyAttribute.DefaultRetriesBeforeFail,
+    private FailMaybeFixedTestCase GetFailTestCase(
+        int defaultRetriesBeforeDeemingNoLongerFlaky = IMaybeFixedAttribute.DefaultRetriesBeforeDeemingNoLongerFlaky,
         IMessageSink? messageSink = null)
     {
-        return new FailFlakyTestCase(
+        return new FailMaybeFixedTestCase(
             messageSink ?? new NullMessageSink(),
             TestMethodDisplay.Method,
             TestMethodDisplayOptions.All,
             _testMethod,
-            retriesBeforeFail,
+            defaultRetriesBeforeDeemingNoLongerFlaky,
             null);
     }
     
-    private SuccessFlakyTestCase GetSuccessTestCase(
-        int retriesBeforeFail = IFlakyAttribute.DefaultRetriesBeforeFail,
+    private SuccessMaybeFixedTestCase GetSuccessTestCase(
+        int defaultRetriesBeforeDeemingNoLongerFlaky = IMaybeFixedAttribute.DefaultRetriesBeforeDeemingNoLongerFlaky,
         IMessageSink? messageSink = null)
     {
-        return new SuccessFlakyTestCase(
+        return new SuccessMaybeFixedTestCase(
             messageSink ?? new NullMessageSink(),
             TestMethodDisplay.Method,
             TestMethodDisplayOptions.All,
             _testMethod,
-            retriesBeforeFail,
+            defaultRetriesBeforeDeemingNoLongerFlaky,
             null);
     }
     
-    private DelayedFlakyTestCase GetDelayedTestCase(
-        int retriesBeforeFail = IFlakyAttribute.DefaultRetriesBeforeFail,
+    private DelayedMaybeFixedTestCase GetDelayedTestCase(
+        int defaultRetriesBeforeDeemingNoLongerFlaky = IMaybeFixedAttribute.DefaultRetriesBeforeDeemingNoLongerFlaky,
         IMessageSink? messageSink = null)
     {
-        return new DelayedFlakyTestCase(
+        return new DelayedMaybeFixedTestCase(
             messageSink ?? new NullMessageSink(),
             TestMethodDisplay.Method,
             TestMethodDisplayOptions.All,
             _testMethod,
-            retriesBeforeFail,
+            defaultRetriesBeforeDeemingNoLongerFlaky,
             null);
     }
 }

--- a/test/FlakyTest.XUnit.Tests/Unit/Models/MaybeFixedTestCaseTests.cs
+++ b/test/FlakyTest.XUnit.Tests/Unit/Models/MaybeFixedTestCaseTests.cs
@@ -40,7 +40,7 @@ public class MaybeFixedTestCaseTests
     public void ShouldSerializeWithExpectedCalls(int retriesBeforeFail)
     {
         var sut = GetSystemUnderTest(retriesBeforeFail);
-        
+
         sut.Serialize(_xunitSerializationInfo.Object);
 
         _xunitSerializationInfo
@@ -69,7 +69,7 @@ public class MaybeFixedTestCaseTests
             .Setup(s => s.QueueMessage(It.IsAny<IMessageSinkMessage>()))
             .Returns(true);
         var messageSink = new Mock<IMessageSink>();
-        
+
         var sut = GetFailTestCase(1, messageSink.Object);
         var runner = new TestableTestCaseRunner<MaybeFixedTestCase>(
             sut,
@@ -85,7 +85,7 @@ public class MaybeFixedTestCaseTests
 
         sut.FlakyDisposition.Should().Be(FlakyDisposition.Fail);
     }
-    
+
     [Fact]
     public async Task ShouldRunAndReportSuccessToDispositionProperty()
     {
@@ -94,7 +94,7 @@ public class MaybeFixedTestCaseTests
             .Setup(s => s.QueueMessage(It.IsAny<IMessageSinkMessage>()))
             .Returns(true);
         var messageSink = new Mock<IMessageSink>();
-        
+
         var sut = GetSuccessTestCase(1, messageSink.Object);
         var runner = new TestableTestCaseRunner<MaybeFixedTestCase>(
             sut,
@@ -110,7 +110,7 @@ public class MaybeFixedTestCaseTests
 
         sut.FlakyDisposition.Should().Be(FlakyDisposition.Success);
     }
-    
+
     [Fact]
     public async Task ShouldRunAndReportCancelledToDispositionProperty()
     {
@@ -137,9 +137,9 @@ public class MaybeFixedTestCaseTests
 
         sut.FlakyDisposition.Should().Be(FlakyDisposition.Cancelled);
     }
-    
+
     private MaybeFixedTestCase GetSystemUnderTest(
-        int defaultRetriesBeforeDeemingNoLongerFlaky = IMaybeFixedAttribute.DefaultRetriesBeforeDeemingNoLongerFlaky, 
+        int defaultRetriesBeforeDeemingNoLongerFlaky = IMaybeFixedAttribute.DefaultRetriesBeforeDeemingNoLongerFlaky,
         IMessageSink? messageSink = null)
     {
         return new MaybeFixedTestCase(
@@ -163,7 +163,7 @@ public class MaybeFixedTestCaseTests
             defaultRetriesBeforeDeemingNoLongerFlaky,
             null);
     }
-    
+
     private SuccessMaybeFixedTestCase GetSuccessTestCase(
         int defaultRetriesBeforeDeemingNoLongerFlaky = IMaybeFixedAttribute.DefaultRetriesBeforeDeemingNoLongerFlaky,
         IMessageSink? messageSink = null)
@@ -176,7 +176,7 @@ public class MaybeFixedTestCaseTests
             defaultRetriesBeforeDeemingNoLongerFlaky,
             null);
     }
-    
+
     private DelayedMaybeFixedTestCase GetDelayedTestCase(
         int defaultRetriesBeforeDeemingNoLongerFlaky = IMaybeFixedAttribute.DefaultRetriesBeforeDeemingNoLongerFlaky,
         IMessageSink? messageSink = null)

--- a/test/FlakyTest.XUnit.Tests/XUnit/InterfaceProxy.cs
+++ b/test/FlakyTest.XUnit.Tests/XUnit/InterfaceProxy.cs
@@ -1,0 +1,6 @@
+﻿namespace FlakyTest.XUnit.Tests.XUnit;
+
+public class InterfaceProxy<T>
+{
+    public override string ToString() { return typeof(T).Name; }
+}

--- a/test/FlakyTest.XUnit.Tests/XUnit/Mocks.cs
+++ b/test/FlakyTest.XUnit.Tests/XUnit/Mocks.cs
@@ -618,7 +618,7 @@ public static class Mocks
         foreach (var traitAttribute in method.GetCustomAttributes(typeof(TraitAttribute)))
         {
             var ctorArgs = traitAttribute.GetConstructorArguments().ToList();
-            result.Add((string)ctorArgs[0], new List<string>() {(string)ctorArgs[1]});
+            result.Add((string)ctorArgs[0], new List<string>() { (string)ctorArgs[1] });
         }
 
         return result;

--- a/test/FlakyTest.XUnit.Tests/XUnit/Mocks.cs
+++ b/test/FlakyTest.XUnit.Tests/XUnit/Mocks.cs
@@ -1,0 +1,625 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using FlakyTest.XUnit.Tests.XUnit;
+using NSubstitute;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+using TestMethodDisplay = Xunit.Sdk.TestMethodDisplay;
+using TestMethodDisplayOptions = Xunit.Sdk.TestMethodDisplayOptions;
+
+public static class Mocks
+{
+    public static IAssemblyInfo AssemblyInfo(ITypeInfo[]? types = null, IReflectionAttributeInfo[]? attributes = null, string? assemblyFileName = null)
+    {
+        attributes = attributes ?? new IReflectionAttributeInfo[0];
+
+        var result = Substitute.For<IAssemblyInfo, InterfaceProxy<IAssemblyInfo>>();
+        result.Name.Returns(assemblyFileName == null ? "assembly:" + Guid.NewGuid().ToString("n") : Path.GetFileNameWithoutExtension(assemblyFileName));
+        result.AssemblyPath.Returns(assemblyFileName);
+        result.GetType("").ReturnsForAnyArgs(types?.FirstOrDefault());
+        result.GetTypes(true).ReturnsForAnyArgs(types ?? new ITypeInfo[0]);
+        result.GetCustomAttributes("").ReturnsForAnyArgs(callInfo => LookupAttribute(callInfo.Arg<string>(), attributes));
+        return result;
+    }
+
+    public static IReflectionAttributeInfo CollectionAttribute(string collectionName)
+    {
+        var result = Substitute.For<IReflectionAttributeInfo, InterfaceProxy<IReflectionAttributeInfo>>();
+        result.Attribute.Returns(new CollectionAttribute(collectionName));
+        result.GetConstructorArguments().Returns(new[] { collectionName });
+        return result;
+    }
+
+    public static IReflectionAttributeInfo CollectionBehaviorAttribute(CollectionBehavior? collectionBehavior = null, bool disableTestParallelization = false, int maxParallelThreads = 0)
+    {
+        CollectionBehaviorAttribute attribute;
+        var result = Substitute.For<IReflectionAttributeInfo, InterfaceProxy<IReflectionAttributeInfo>>();
+
+        if (collectionBehavior.HasValue)
+        {
+            attribute = new CollectionBehaviorAttribute(collectionBehavior.GetValueOrDefault());
+            result.GetConstructorArguments().Returns(new object[] { collectionBehavior });
+        }
+        else
+        {
+            attribute = new CollectionBehaviorAttribute();
+            result.GetConstructorArguments().Returns(new object[0]);
+        }
+
+        attribute.DisableTestParallelization = disableTestParallelization;
+        attribute.MaxParallelThreads = maxParallelThreads;
+
+        result.Attribute.Returns(attribute);
+        result.GetNamedArgument<bool>("DisableTestParallelization").Returns(disableTestParallelization);
+        result.GetNamedArgument<int>("MaxParallelThreads").Returns(maxParallelThreads);
+        return result;
+    }
+
+    public static IReflectionAttributeInfo CollectionBehaviorAttribute(string factoryTypeName, string factoryAssemblyName, bool disableTestParallelization = false, int maxParallelThreads = 0)
+    {
+        var attribute = new CollectionBehaviorAttribute(factoryTypeName, factoryAssemblyName)
+        {
+            DisableTestParallelization = disableTestParallelization,
+            MaxParallelThreads = maxParallelThreads
+        };
+        var result = Substitute.For<IReflectionAttributeInfo, InterfaceProxy<IReflectionAttributeInfo>>();
+        result.Attribute.Returns(attribute);
+        result.GetNamedArgument<bool>("DisableTestParallelization").Returns(disableTestParallelization);
+        result.GetNamedArgument<int>("MaxParallelThreads").Returns(maxParallelThreads);
+        result.GetConstructorArguments().Returns(new object[] { factoryTypeName, factoryAssemblyName });
+        return result;
+    }
+
+    public static IReflectionAttributeInfo CollectionDefinitionAttribute(string collectionName)
+    {
+        var result = Substitute.For<IReflectionAttributeInfo, InterfaceProxy<IReflectionAttributeInfo>>();
+        result.Attribute.Returns(new CollectionDefinitionAttribute(collectionName));
+        result.GetConstructorArguments().Returns(new[] { collectionName });
+        return result;
+    }
+
+    public static IReflectionAttributeInfo DataAttribute(IEnumerable<object[]>? data = null)
+    {
+        var result = Substitute.For<IReflectionAttributeInfo, InterfaceProxy<IReflectionAttributeInfo>>();
+        var dataAttribute = Substitute.For<DataAttribute>();
+        dataAttribute.GetData(null).ReturnsForAnyArgs(data);
+        result.Attribute.Returns(dataAttribute);
+        return result;
+    }
+
+    public static ExecutionErrorTestCase ExecutionErrorTestCase(string message, IMessageSink? diagnosticMessageSink = null)
+    {
+        var testMethod = TestMethod();
+        return new ExecutionErrorTestCase(diagnosticMessageSink ?? new NullMessageSink(), TestMethodDisplay.ClassAndMethod, TestMethodDisplayOptions.None, testMethod, message);
+    }
+
+    public static IReflectionAttributeInfo FactAttribute(string? displayName = null, string? skip = null, int timeout = 0)
+    {
+        var result = Substitute.For<IReflectionAttributeInfo, InterfaceProxy<IReflectionAttributeInfo>>();
+        result.Attribute.Returns(new FactAttribute { DisplayName = displayName, Skip = skip, Timeout = timeout });
+        result.GetNamedArgument<string>("DisplayName").Returns(displayName);
+        result.GetNamedArgument<string>("Skip").Returns(skip);
+        result.GetNamedArgument<int>("Timeout").Returns(timeout);
+        return result;
+    }
+
+    static IEnumerable<IAttributeInfo> LookupAttribute(string fullyQualifiedTypeName, IReflectionAttributeInfo[]? attributes)
+    {
+        if (attributes == null)
+            return Enumerable.Empty<IAttributeInfo>();
+
+        var attributeType = Type.GetType(fullyQualifiedTypeName);
+        if (attributeType == null)
+            return Enumerable.Empty<IAttributeInfo>();
+
+        return attributes.Where(attribute => attributeType.IsAssignableFrom(attribute.Attribute.GetType())).ToList();
+    }
+
+    public static IMethodInfo MethodInfo(string? methodName = null,
+                                         IReflectionAttributeInfo[]? attributes = null,
+                                         IParameterInfo[]? parameters = null,
+                                         ITypeInfo? type = null,
+                                         ITypeInfo? returnType = null,
+                                         bool isAbstract = false,
+                                         bool isPublic = true,
+                                         bool isStatic = false)
+    {
+        var result = Substitute.For<IMethodInfo, InterfaceProxy<IMethodInfo>>();
+
+        attributes = attributes ?? new IReflectionAttributeInfo[0];
+        parameters = parameters ?? new IParameterInfo[0];
+
+        result.IsAbstract.Returns(isAbstract);
+        result.IsPublic.Returns(isPublic);
+        result.IsStatic.Returns(isStatic);
+        result.Name.Returns(methodName ?? "method:" + Guid.NewGuid().ToString("n"));
+        result.ReturnType.Returns(returnType);
+        result.Type.Returns(type);
+        result.GetCustomAttributes("").ReturnsForAnyArgs(callInfo => LookupAttribute(callInfo.Arg<string>(), attributes));
+        result.GetParameters().Returns(parameters);
+
+        return result;
+    }
+
+    public static IParameterInfo ParameterInfo(string name)
+    {
+        var result = Substitute.For<IParameterInfo, InterfaceProxy<IParameterInfo>>();
+        result.Name.Returns(name);
+        return result;
+    }
+
+    public static IReflectionMethodInfo ReflectionMethodInfo<TClass>(string methodName)
+    {
+        return Reflector.Wrap(typeof(TClass).GetMethod(methodName));
+    }
+
+    public static IReflectionTypeInfo ReflectionTypeInfo<TClass>()
+    {
+        return Reflector.Wrap(typeof(TClass));
+    }
+
+    // public static IRunnerReporter RunnerReporter(string runnerSwitch = null,
+    //                                              string description = null,
+    //                                              bool isEnvironmentallyEnabled = false,
+    //                                              IMessageSinkWithTypes messageSink = null)
+    // {
+    //     var result = Substitute.For<IRunnerReporter, InterfaceProxy<IRunnerReporter>>();
+    //     result.Description.Returns(description ?? "The runner reporter description");
+    //     result.IsEnvironmentallyEnabled.ReturnsForAnyArgs(isEnvironmentallyEnabled);
+    //     result.RunnerSwitch.Returns(runnerSwitch);
+    //     var dualSink = MessageSinkAdapter.Wrap(messageSink ?? Substitute.For<IMessageSinkWithTypes, InterfaceProxy<IMessageSinkWithTypes>>());
+    //     result.CreateMessageHandler(null).ReturnsForAnyArgs(dualSink);
+    //     return result;
+    // }
+
+    public static ITest Test(ITestCase? testCase, string? displayName)
+    {
+        var result = Substitute.For<ITest, InterfaceProxy<ITest>>();
+        result.DisplayName.Returns(displayName);
+        result.TestCase.Returns(testCase);
+        return result;
+    }
+
+    public static ITestAssembly TestAssembly(IReflectionAttributeInfo[] attributes)
+    {
+        var assemblyInfo = AssemblyInfo(attributes: attributes);
+
+        var result = Substitute.For<ITestAssembly, InterfaceProxy<ITestAssembly>>();
+        result.Assembly.Returns(assemblyInfo);
+        return result;
+    }
+
+    public static ITestAssembly TestAssembly(string assemblyFileName, string? configFileName = null, ITypeInfo[]? types = null, IReflectionAttributeInfo[]? attributes = null)
+    {
+        var assemblyInfo = AssemblyInfo(types, attributes, assemblyFileName);
+
+        var result = Substitute.For<ITestAssembly, InterfaceProxy<ITestAssembly>>();
+        result.Assembly.Returns(assemblyInfo);
+        result.ConfigFileName.Returns(configFileName);
+        return result;
+    }
+
+    public static TestAssembly TestAssembly(Assembly? assembly = null, string? configFileName = null)
+    {
+#if NETFRAMEWORK
+        if (configFileName == null)
+            configFileName = AppDomain.CurrentDomain.SetupInformation.ConfigurationFile;
+#endif
+
+        return new TestAssembly(Reflector.Wrap(assembly ?? typeof(Mocks).GetTypeInfo().Assembly), configFileName);
+    }
+
+    // public static ITestAssemblyDiscoveryFinished TestAssemblyDiscoveryFinished(bool diagnosticMessages = false, int toRun = 42, int discovered = 2112)
+    // {
+    //     var assembly = new XunitProjectAssembly { AssemblyFilename = "testAssembly.dll", ConfigFilename = "testAssembly.dll.config" };
+    //     var config = new TestAssemblyConfiguration { DiagnosticMessages = diagnosticMessages, ShadowCopy = true };
+    //     var result = Substitute.For<ITestAssemblyDiscoveryFinished, InterfaceProxy<ITestAssemblyDiscoveryFinished>>();
+    //     result.Assembly.Returns(assembly);
+    //     result.DiscoveryOptions.Returns(TestFrameworkOptions.ForDiscovery(config));
+    //     result.TestCasesDiscovered.Returns(discovered);
+    //     result.TestCasesToRun.Returns(toRun);
+    //     return result;
+    // }
+    //
+    // public static ITestAssemblyDiscoveryStarting TestAssemblyDiscoveryStarting(bool diagnosticMessages = false, bool appDomain = false)
+    // {
+    //     var assembly = new XunitProjectAssembly { AssemblyFilename = "testAssembly.dll", ConfigFilename = "testAssembly.dll.config" };
+    //     var config = new TestAssemblyConfiguration { DiagnosticMessages = diagnosticMessages, MethodDisplay = Xunit.TestMethodDisplay.ClassAndMethod, MaxParallelThreads = 42, ParallelizeTestCollections = true, ShadowCopy = true };
+    //     var result = Substitute.For<ITestAssemblyDiscoveryStarting, InterfaceProxy<ITestAssemblyDiscoveryStarting>>();
+    //     result.AppDomain.Returns(appDomain);
+    //     result.Assembly.Returns(assembly);
+    //     result.DiscoveryOptions.Returns(TestFrameworkOptions.ForDiscovery(config));
+    //     return result;
+    // }
+    //
+    // public static ITestAssemblyExecutionFinished TestAssemblyExecutionFinished(bool diagnosticMessages = false, int total = 2112, int failed = 42, int skipped = 8, int errors = 6, decimal time = 123.456M)
+    // {
+    //     var assembly = new XunitProjectAssembly { AssemblyFilename = "testAssembly.dll", ConfigFilename = "testAssembly.dll.config" };
+    //     var config = new TestAssemblyConfiguration { DiagnosticMessages = diagnosticMessages, ShadowCopy = true };
+    //     var summary = new ExecutionSummary { Total = total, Failed = failed, Skipped = skipped, Errors = errors, Time = time };
+    //     var result = Substitute.For<ITestAssemblyExecutionFinished, InterfaceProxy<ITestAssemblyExecutionFinished>>();
+    //     result.Assembly.Returns(assembly);
+    //     result.ExecutionOptions.Returns(TestFrameworkOptions.ForExecution(config));
+    //     result.ExecutionSummary.Returns(summary);
+    //     return result;
+    // }
+    //
+    // public static ITestAssemblyExecutionStarting TestAssemblyExecutionStarting(bool diagnosticMessages = false, string assemblyFilename = null)
+    // {
+    //     var assembly = new XunitProjectAssembly { AssemblyFilename = assemblyFilename ?? "testAssembly.dll", ConfigFilename = "testAssembly.dll.config" };
+    //     var config = new TestAssemblyConfiguration { DiagnosticMessages = diagnosticMessages, MethodDisplay = Xunit.TestMethodDisplay.ClassAndMethod, MaxParallelThreads = 42, ParallelizeTestCollections = true, ShadowCopy = true };
+    //     var result = Substitute.For<ITestAssemblyExecutionStarting, InterfaceProxy<ITestAssemblyExecutionStarting>>();
+    //     result.Assembly.Returns(assembly);
+    //     result.ExecutionOptions.Returns(TestFrameworkOptions.ForExecution(config));
+    //     return result;
+    // }
+    //
+    // public static ITestAssemblyFinished TestAssemblyFinished(int testsRun = 2112, int testsFailed = 42, int testsSkipped = 6, decimal executionTime = 123.4567M)
+    // {
+    //     var testAssembly = TestAssembly("testAssembly.dll");
+    //     var result = Substitute.For<ITestAssemblyFinished, InterfaceProxy<ITestAssemblyFinished>>();
+    //     result.TestAssembly.Returns(testAssembly);
+    //     result.TestsRun.Returns(testsRun);
+    //     result.TestsFailed.Returns(testsFailed);
+    //     result.TestsSkipped.Returns(testsSkipped);
+    //     result.ExecutionTime.Returns(executionTime);
+    //     return result;
+    // }
+    //
+    // public static ITestAssemblyStarting TestAssemblyStarting()
+    // {
+    //     var testAssembly = TestAssembly("testAssembly.dll");
+    //     var result = Substitute.For<ITestAssemblyStarting, InterfaceProxy<ITestAssemblyStarting>>();
+    //     result.TestAssembly.Returns(testAssembly);
+    //     return result;
+    // }
+
+    public static ITestCase TestCase(ITestCollection? collection = null)
+    {
+        if (collection == null)
+            collection = TestCollection();
+
+        var result = Substitute.For<ITestCase, InterfaceProxy<ITestCase>>();
+        result.TestMethod.TestClass.TestCollection.Returns(collection);
+        return result;
+    }
+
+    public static ITestCase TestCase(ITestMethod testMethod)
+    {
+        var result = Substitute.For<ITestCase, InterfaceProxy<ITestCase>>();
+        result.TestMethod.Returns(testMethod);
+        return result;
+    }
+
+    public static ITestCase TestCase<TClassUnderTest>(string methodName, string? displayName = null, string? skipReason = null, string? uniqueID = null)
+    {
+        return TestCase(typeof(TClassUnderTest), methodName, displayName, skipReason, uniqueID);
+    }
+
+    public static ITestCase TestCase(Type type, string methodName, string? displayName = null, string? skipReason = null, string? uniqueID = null)
+    {
+        var testMethod = TestMethod(type, methodName);
+        var traits = GetTraits(testMethod.Method);
+
+        var result = Substitute.For<ITestCase, InterfaceProxy<ITestCase>>();
+        result.DisplayName.Returns(displayName ?? $"{type}.{methodName}");
+        result.SkipReason.Returns(skipReason);
+        result.TestMethod.Returns(testMethod);
+        result.Traits.Returns(traits);
+        result.UniqueID.Returns(uniqueID ?? Guid.NewGuid().ToString());
+        return result;
+    }
+
+    public static IReflectionAttributeInfo TestCaseOrdererAttribute(string typeName, string assemblyName)
+    {
+        var result = Substitute.For<IReflectionAttributeInfo, InterfaceProxy<IReflectionAttributeInfo>>();
+        result.Attribute.Returns(new TestCaseOrdererAttribute(typeName, assemblyName));
+        result.GetConstructorArguments().Returns(new object[] { typeName, assemblyName });
+        return result;
+    }
+
+    public static IReflectionAttributeInfo TestCaseOrdererAttribute<TOrderer>()
+    {
+        var ordererType = typeof(TOrderer);
+        return TestCaseOrdererAttribute(ordererType.FullName!, ordererType.GetTypeInfo().Assembly.FullName!);
+    }
+
+    public static ITestClass TestClass(string? typeName, IReflectionAttributeInfo[]? attributes = null)
+    {
+        var testCollection = TestCollection();
+        var typeInfo = TypeInfo(typeName, attributes: attributes);
+
+        var result = Substitute.For<ITestClass, InterfaceProxy<ITestClass>>();
+        result.Class.Returns(typeInfo);
+        result.TestCollection.Returns(testCollection);
+        return result;
+    }
+
+    public static TestClass TestClass(Type type, ITestCollection? collection = null)
+    {
+        if (collection == null)
+            collection = TestCollection(type.GetTypeInfo().Assembly);
+
+        return new TestClass(collection, Reflector.Wrap(type));
+    }
+
+    public static TestCollection TestCollection(Assembly? assembly = null, ITypeInfo? definition = null, string? displayName = null)
+    {
+        if (assembly == null)
+            assembly = typeof(Mocks).GetTypeInfo().Assembly;
+        if (displayName == null)
+            displayName = "Mock test collection for " + assembly.Location!;
+
+        return new TestCollection(TestAssembly(assembly), definition, displayName);
+    }
+
+    public static ITestCollectionFinished TestCollectionFinished(string displayName = "Display Name", int testsRun = 2112, int testsFailed = 42, int testsSkipped = 6, decimal executionTime = 123.4567M)
+    {
+        var result = Substitute.For<ITestCollectionFinished, InterfaceProxy<ITestCollectionFinished>>();
+        result.TestsRun.Returns(testsRun);
+        result.TestsFailed.Returns(testsFailed);
+        result.TestsSkipped.Returns(testsSkipped);
+        result.ExecutionTime.Returns(executionTime);
+        result.TestCollection.DisplayName.Returns(displayName);
+        return result;
+    }
+
+    public static ITestCollectionStarting TestCollectionStarting()
+    {
+        var result = Substitute.For<ITestCollectionStarting, InterfaceProxy<ITestCollectionStarting>>();
+        result.TestCollection.DisplayName.Returns("Display Name");
+        return result;
+    }
+
+    public static IReflectionAttributeInfo TestCollectionOrdererAttribute(string typeName, string assemblyName)
+    {
+        var result = Substitute.For<IReflectionAttributeInfo, InterfaceProxy<IReflectionAttributeInfo>>();
+        result.Attribute.Returns(new TestCollectionOrdererAttribute(typeName, assemblyName));
+        result.GetConstructorArguments().Returns(new object[] { typeName, assemblyName });
+        return result;
+    }
+
+    public static IReflectionAttributeInfo TestCollectionOrdererAttribute<TOrderer>()
+    {
+        var ordererType = typeof(TOrderer);
+        return TestCollectionOrdererAttribute(ordererType.FullName!, ordererType.GetTypeInfo().Assembly.FullName!);
+    }
+
+    public static ITestFailed TestFailed(Type type, string methodName, string? displayName = null, string? output = null, decimal executionTime = 0M, Exception? ex = null)
+    {
+        var testCase = TestCase(type, methodName);
+        var test = Test(testCase, displayName ?? "NO DISPLAY NAME");
+        var failureInfo = Xunit.Sdk.ExceptionUtility.ConvertExceptionToFailureInformation(ex ?? new Exception());
+
+        var result = Substitute.For<ITestFailed, InterfaceProxy<ITestFailed>>();
+        result.ExceptionParentIndices.Returns(failureInfo.ExceptionParentIndices);
+        result.ExceptionTypes.Returns(failureInfo.ExceptionTypes);
+        result.ExecutionTime.Returns(executionTime);
+        result.Messages.Returns(failureInfo.Messages);
+        result.Output.Returns(output);
+        result.StackTraces.Returns(failureInfo.StackTraces);
+        result.TestCase.Returns(testCase);
+        result.Test.Returns(test);
+        return result;
+    }
+
+    public static ITestFailed TestFailed(string? displayName, decimal executionTime, string? exceptionType = null, string? exceptionMessage = null, string? stackTrace = null, string? output = null)
+    {
+        var testCase = TestCase();
+        var test = Test(testCase, displayName);
+        var result = Substitute.For<ITestFailed, InterfaceProxy<ITestFailed>>();
+        result.ExceptionParentIndices.Returns(new[] { -1 });
+        result.ExceptionTypes.Returns(new[] { exceptionType });
+        result.ExecutionTime.Returns(executionTime);
+        result.Messages.Returns(new[] { exceptionMessage });
+        result.Output.Returns(output);
+        result.StackTraces.Returns(new[] { stackTrace });
+        result.TestCase.Returns(testCase);
+        result.Test.Returns(test);
+        return result;
+    }
+
+    public static IReflectionAttributeInfo TestFrameworkAttribute(Type type)
+    {
+        var attribute = Activator.CreateInstance(type);
+        var result = Substitute.For<IReflectionAttributeInfo, InterfaceProxy<IReflectionAttributeInfo>>();
+        result.Attribute.Returns(attribute);
+        result.GetCustomAttributes(null).ReturnsForAnyArgs(callInfo => LookupAttribute(callInfo.Arg<string>(), CustomAttributeData.GetCustomAttributes(attribute!.GetType().GetTypeInfo()).Select(Reflector.Wrap).ToArray()));
+        return result;
+    }
+
+    public static ITestMethod TestMethod(string? typeName = null,
+                                         string? methodName = null,
+                                         string? displayName = null,
+                                         string? skip = null,
+                                         int timeout = 0,
+                                         IEnumerable<IParameterInfo>? parameters = null,
+                                         IEnumerable<IReflectionAttributeInfo>? classAttributes = null,
+                                         IEnumerable<IReflectionAttributeInfo>? methodAttributes = null)
+    {
+        if (classAttributes == null)
+            classAttributes = Enumerable.Empty<IReflectionAttributeInfo>();
+        if (methodAttributes == null)
+            methodAttributes = Enumerable.Empty<IReflectionAttributeInfo>();
+        if (parameters == null)
+            parameters = Enumerable.Empty<IParameterInfo>();
+
+        var factAttribute = methodAttributes.FirstOrDefault(attr => typeof(FactAttribute).IsAssignableFrom(attr.Attribute.GetType()));
+        if (factAttribute == null)
+        {
+            factAttribute = FactAttribute(displayName, skip, timeout);
+            methodAttributes = methodAttributes.Concat(new[] { factAttribute });
+        }
+
+        var testClass = TestClass(typeName, attributes: classAttributes.ToArray());
+        var methodInfo = MethodInfo(methodName, methodAttributes.ToArray(), parameters.ToArray(), testClass.Class);
+
+        var result = Substitute.For<ITestMethod, InterfaceProxy<ITestMethod>>();
+        result.Method.Returns(methodInfo);
+        result.TestClass.Returns(testClass);
+        return result;
+    }
+
+    public static TestMethod TestMethod(Type type, string methodName, ITestCollection? collection = null)
+    {
+        var @class = TestClass(type, collection);
+        var methodInfo = type.GetMethod(methodName);
+        if (methodInfo == null)
+            throw new Exception($"Unknown method: {type.FullName}.{methodName}");
+
+        return new TestMethod(@class, Reflector.Wrap(methodInfo));
+    }
+
+    public static ITestPassed TestPassed(Type type, string methodName, string? displayName = null, string? output = null, decimal executionTime = 0M)
+    {
+        var testCase = TestCase(type, methodName);
+        var test = Test(testCase, displayName ?? "NO DISPLAY NAME");
+
+        var result = Substitute.For<ITestPassed, InterfaceProxy<ITestPassed>>();
+        result.ExecutionTime.Returns(executionTime);
+        result.Output.Returns(output);
+        result.TestCase.Returns(testCase);
+        result.Test.Returns(test);
+        return result;
+    }
+
+    public static ITestPassed TestPassed(string displayName, string? output = null)
+    {
+        var testCase = TestCase();
+        var test = Test(testCase, displayName);
+        var result = Substitute.For<ITestPassed, InterfaceProxy<ITestPassed>>();
+        result.Test.Returns(test);
+        result.ExecutionTime.Returns(1.2345M);
+        result.Output.Returns(output);
+        return result;
+    }
+
+    public static ITestResultMessage TestResult<TClassUnderTest>(string methodName, string displayName, decimal executionTime)
+    {
+        var testCase = TestCase<TClassUnderTest>(methodName);
+        var test = Test(testCase, displayName);
+        var result = Substitute.For<ITestResultMessage, InterfaceProxy<ITestResultMessage>>();
+        result.TestCase.Returns(testCase);
+        result.Test.Returns(test);
+        result.ExecutionTime.Returns(executionTime);
+        return result;
+    }
+
+    public static ITestSkipped TestSkipped(Type type, string methodName, string? displayName = null, string? output = null, decimal executionTime = 0M, string? skipReason = null)
+    {
+        var testCase = TestCase(type, methodName);
+        var test = Test(testCase, displayName ?? "NO DISPLAY NAME");
+
+        var result = Substitute.For<ITestSkipped, InterfaceProxy<ITestSkipped>>();
+        result.ExecutionTime.Returns(executionTime);
+        result.Output.Returns(output);
+        result.Reason.Returns(skipReason);
+        result.TestCase.Returns(testCase);
+        result.Test.Returns(test);
+        return result;
+    }
+
+    public static ITestSkipped TestSkipped(string displayName, string? skipReason = null)
+    {
+        var testCase = TestCase();
+        var test = Test(testCase, displayName);
+
+        var result = Substitute.For<ITestSkipped, InterfaceProxy<ITestSkipped>>();
+        result.Reason.Returns(skipReason);
+        result.TestCase.Returns(testCase);
+        result.Test.Returns(test);
+        return result;
+    }
+
+    public static ITestStarting TestStarting(string displayName)
+    {
+        var testCase = TestCase();
+        var test = Test(testCase, displayName);
+        var result = Substitute.For<ITestStarting, InterfaceProxy<ITestStarting>>();
+        result.Test.Returns(test);
+        return result;
+    }
+
+    public static IReflectionAttributeInfo TheoryAttribute(string? displayName = null, string? skip = null, int timeout = 0)
+    {
+        var result = Substitute.For<IReflectionAttributeInfo, InterfaceProxy<IReflectionAttributeInfo>>();
+        result.Attribute.Returns(new TheoryAttribute { DisplayName = displayName, Skip = skip });
+        result.GetNamedArgument<string>("DisplayName").Returns(displayName);
+        result.GetNamedArgument<string>("Skip").Returns(skip);
+        result.GetNamedArgument<int>("Timeout").Returns(timeout);
+        return result;
+    }
+
+    public static IReflectionAttributeInfo TraitAttribute<T>()
+        where T : Attribute, new()
+    {
+        var result = Substitute.For<IReflectionAttributeInfo, InterfaceProxy<IReflectionAttributeInfo>>();
+        result.Attribute.Returns(new T());
+        return result;
+    }
+
+    public static IReflectionAttributeInfo TraitAttribute(string name, string value)
+    {
+        var result = Substitute.For<IReflectionAttributeInfo, InterfaceProxy<IReflectionAttributeInfo>>();
+        var traitDiscovererAttributes = new[] { TraitDiscovererAttribute() };
+        result.GetCustomAttributes(typeof(TraitDiscovererAttribute)).Returns(traitDiscovererAttributes);
+        result.Attribute.Returns(new TraitAttribute(name, value));
+        result.GetConstructorArguments().Returns(new object[] { name, value });
+        return result;
+    }
+
+    public static IAttributeInfo TraitDiscovererAttribute(string typeName = "Xunit.Sdk.TraitDiscoverer", string assemblyName = "xunit.core")
+    {
+        var result = Substitute.For<IReflectionAttributeInfo, InterfaceProxy<IReflectionAttributeInfo>>();
+        result.Attribute.Returns(new TraitDiscovererAttribute(typeName, assemblyName));
+        result.GetConstructorArguments().Returns(new object[] { typeName, assemblyName });
+        return result;
+    }
+
+    public static ITypeInfo TypeInfo(string? typeName = null,
+                                     IMethodInfo[]? methods = null,
+                                     IReflectionAttributeInfo[]? attributes = null,
+                                     string? assemblyFileName = null)
+    {
+        var result = Substitute.For<ITypeInfo, InterfaceProxy<ITypeInfo>>();
+        result.Name.Returns(typeName ?? "type:" + Guid.NewGuid().ToString("n"));
+        result.GetMethods(false).ReturnsForAnyArgs(methods ?? new IMethodInfo[0]);
+        var assemblyInfo = AssemblyInfo(assemblyFileName: assemblyFileName);
+        result.Assembly.Returns(assemblyInfo);
+        result.GetCustomAttributes("").ReturnsForAnyArgs(callInfo => LookupAttribute(callInfo.Arg<string>(), attributes));
+        return result;
+    }
+
+    public static XunitTestCase XunitTestCase<TClassUnderTest>(string methodName, ITestCollection? collection = null, object[]? testMethodArguments = null, IMessageSink? diagnosticMessageSink = null)
+    {
+        var method = TestMethod(typeof(TClassUnderTest), methodName, collection);
+
+        return new XunitTestCase(diagnosticMessageSink ?? new NullMessageSink(), TestMethodDisplay.ClassAndMethod, TestMethodDisplayOptions.None, method, testMethodArguments);
+    }
+
+    public static XunitTheoryTestCase XunitTheoryTestCase<TClassUnderTest>(string methodName, ITestCollection? collection = null, IMessageSink? diagnosticMessageSink = null)
+    {
+        var method = TestMethod(typeof(TClassUnderTest), methodName, collection);
+
+        return new XunitTheoryTestCase(diagnosticMessageSink ?? new NullMessageSink(), TestMethodDisplay.ClassAndMethod, TestMethodDisplayOptions.None, method);
+    }
+
+    // Helpers
+
+    private static Dictionary<string, List<string>> GetTraits(IMethodInfo method)
+    {
+        var result = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var traitAttribute in method.GetCustomAttributes(typeof(TraitAttribute)))
+        {
+            var ctorArgs = traitAttribute.GetConstructorArguments().ToList();
+            result.Add((string)ctorArgs[0], new List<string>() {(string)ctorArgs[1]});
+        }
+
+        return result;
+    }
+}

--- a/test/FlakyTest.XUnit.Tests/XUnit/Mocks.cs
+++ b/test/FlakyTest.XUnit.Tests/XUnit/Mocks.cs
@@ -8,7 +8,7 @@ using NSubstitute;
 using Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;
-using NullMessageSink = Xunit.NullMessageSink;
+using NullMessageSink = Xunit.Sdk.NullMessageSink;
 using TestMethodDisplay = Xunit.Sdk.TestMethodDisplay;
 using TestMethodDisplayOptions = Xunit.Sdk.TestMethodDisplayOptions;
 
@@ -163,20 +163,6 @@ public static class Mocks
         return Reflector.Wrap(typeof(TClass));
     }
 
-    public static IRunnerReporter RunnerReporter(string? runnerSwitch = null,
-                                                 string? description = null,
-                                                 bool isEnvironmentallyEnabled = false,
-                                                 IMessageSinkWithTypes? messageSink = null)
-    {
-        var result = Substitute.For<IRunnerReporter, InterfaceProxy<IRunnerReporter>>();
-        result.Description.Returns(description ?? "The runner reporter description");
-        result.IsEnvironmentallyEnabled.ReturnsForAnyArgs(isEnvironmentallyEnabled);
-        result.RunnerSwitch.Returns(runnerSwitch);
-        var dualSink = MessageSinkAdapter.Wrap(messageSink ?? Substitute.For<IMessageSinkWithTypes, InterfaceProxy<IMessageSinkWithTypes>>());
-        result.CreateMessageHandler(null).ReturnsForAnyArgs(dualSink);
-        return result;
-    }
-
     public static ITest Test(ITestCase? testCase, string? displayName)
     {
         var result = Substitute.For<ITest, InterfaceProxy<ITest>>();
@@ -213,71 +199,6 @@ public static class Mocks
 
         return new TestAssembly(Reflector.Wrap(assembly ?? typeof(Mocks).GetTypeInfo().Assembly), configFileName);
     }
-
-    // public static ITestAssemblyDiscoveryFinished TestAssemblyDiscoveryFinished(bool diagnosticMessages = false, int toRun = 42, int discovered = 2112)
-    // {
-    //     var assembly = new XunitProjectAssembly { AssemblyFilename = "testAssembly.dll", ConfigFilename = "testAssembly.dll.config" };
-    //     var config = new TestAssemblyConfiguration { DiagnosticMessages = diagnosticMessages, ShadowCopy = true };
-    //     var result = Substitute.For<ITestAssemblyDiscoveryFinished, InterfaceProxy<ITestAssemblyDiscoveryFinished>>();
-    //     result.Assembly.Returns(assembly);
-    //     result.DiscoveryOptions.Returns(TestFrameworkOptions.ForDiscovery(config));
-    //     result.TestCasesDiscovered.Returns(discovered);
-    //     result.TestCasesToRun.Returns(toRun);
-    //     return result;
-    // }
-    //
-    // public static ITestAssemblyDiscoveryStarting TestAssemblyDiscoveryStarting(bool diagnosticMessages = false, bool appDomain = false)
-    // {
-    //     var assembly = new XunitProjectAssembly { AssemblyFilename = "testAssembly.dll", ConfigFilename = "testAssembly.dll.config" };
-    //     var config = new TestAssemblyConfiguration { DiagnosticMessages = diagnosticMessages, MethodDisplay = Xunit.TestMethodDisplay.ClassAndMethod, MaxParallelThreads = 42, ParallelizeTestCollections = true, ShadowCopy = true };
-    //     var result = Substitute.For<ITestAssemblyDiscoveryStarting, InterfaceProxy<ITestAssemblyDiscoveryStarting>>();
-    //     result.AppDomain.Returns(appDomain);
-    //     result.Assembly.Returns(assembly);
-    //     result.DiscoveryOptions.Returns(TestFrameworkOptions.ForDiscovery(config));
-    //     return result;
-    // }
-    //
-    // public static ITestAssemblyExecutionFinished TestAssemblyExecutionFinished(bool diagnosticMessages = false, int total = 2112, int failed = 42, int skipped = 8, int errors = 6, decimal time = 123.456M)
-    // {
-    //     var assembly = new XunitProjectAssembly { AssemblyFilename = "testAssembly.dll", ConfigFilename = "testAssembly.dll.config" };
-    //     var config = new TestAssemblyConfiguration { DiagnosticMessages = diagnosticMessages, ShadowCopy = true };
-    //     var summary = new ExecutionSummary { Total = total, Failed = failed, Skipped = skipped, Errors = errors, Time = time };
-    //     var result = Substitute.For<ITestAssemblyExecutionFinished, InterfaceProxy<ITestAssemblyExecutionFinished>>();
-    //     result.Assembly.Returns(assembly);
-    //     result.ExecutionOptions.Returns(TestFrameworkOptions.ForExecution(config));
-    //     result.ExecutionSummary.Returns(summary);
-    //     return result;
-    // }
-    //
-    // public static ITestAssemblyExecutionStarting TestAssemblyExecutionStarting(bool diagnosticMessages = false, string assemblyFilename = null)
-    // {
-    //     var assembly = new XunitProjectAssembly { AssemblyFilename = assemblyFilename ?? "testAssembly.dll", ConfigFilename = "testAssembly.dll.config" };
-    //     var config = new TestAssemblyConfiguration { DiagnosticMessages = diagnosticMessages, MethodDisplay = Xunit.TestMethodDisplay.ClassAndMethod, MaxParallelThreads = 42, ParallelizeTestCollections = true, ShadowCopy = true };
-    //     var result = Substitute.For<ITestAssemblyExecutionStarting, InterfaceProxy<ITestAssemblyExecutionStarting>>();
-    //     result.Assembly.Returns(assembly);
-    //     result.ExecutionOptions.Returns(TestFrameworkOptions.ForExecution(config));
-    //     return result;
-    // }
-    //
-    // public static ITestAssemblyFinished TestAssemblyFinished(int testsRun = 2112, int testsFailed = 42, int testsSkipped = 6, decimal executionTime = 123.4567M)
-    // {
-    //     var testAssembly = TestAssembly("testAssembly.dll");
-    //     var result = Substitute.For<ITestAssemblyFinished, InterfaceProxy<ITestAssemblyFinished>>();
-    //     result.TestAssembly.Returns(testAssembly);
-    //     result.TestsRun.Returns(testsRun);
-    //     result.TestsFailed.Returns(testsFailed);
-    //     result.TestsSkipped.Returns(testsSkipped);
-    //     result.ExecutionTime.Returns(executionTime);
-    //     return result;
-    // }
-    //
-    // public static ITestAssemblyStarting TestAssemblyStarting()
-    // {
-    //     var testAssembly = TestAssembly("testAssembly.dll");
-    //     var result = Substitute.For<ITestAssemblyStarting, InterfaceProxy<ITestAssemblyStarting>>();
-    //     result.TestAssembly.Returns(testAssembly);
-    //     return result;
-    // }
 
     public static ITestCase TestCase(ITestCollection? collection = null)
     {

--- a/test/FlakyTest.XUnit.Tests/XUnit/Mocks.cs
+++ b/test/FlakyTest.XUnit.Tests/XUnit/Mocks.cs
@@ -8,6 +8,7 @@ using NSubstitute;
 using Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;
+using NullMessageSink = Xunit.NullMessageSink;
 using TestMethodDisplay = Xunit.Sdk.TestMethodDisplay;
 using TestMethodDisplayOptions = Xunit.Sdk.TestMethodDisplayOptions;
 
@@ -162,19 +163,19 @@ public static class Mocks
         return Reflector.Wrap(typeof(TClass));
     }
 
-    // public static IRunnerReporter RunnerReporter(string runnerSwitch = null,
-    //                                              string description = null,
-    //                                              bool isEnvironmentallyEnabled = false,
-    //                                              IMessageSinkWithTypes messageSink = null)
-    // {
-    //     var result = Substitute.For<IRunnerReporter, InterfaceProxy<IRunnerReporter>>();
-    //     result.Description.Returns(description ?? "The runner reporter description");
-    //     result.IsEnvironmentallyEnabled.ReturnsForAnyArgs(isEnvironmentallyEnabled);
-    //     result.RunnerSwitch.Returns(runnerSwitch);
-    //     var dualSink = MessageSinkAdapter.Wrap(messageSink ?? Substitute.For<IMessageSinkWithTypes, InterfaceProxy<IMessageSinkWithTypes>>());
-    //     result.CreateMessageHandler(null).ReturnsForAnyArgs(dualSink);
-    //     return result;
-    // }
+    public static IRunnerReporter RunnerReporter(string? runnerSwitch = null,
+                                                 string? description = null,
+                                                 bool isEnvironmentallyEnabled = false,
+                                                 IMessageSinkWithTypes? messageSink = null)
+    {
+        var result = Substitute.For<IRunnerReporter, InterfaceProxy<IRunnerReporter>>();
+        result.Description.Returns(description ?? "The runner reporter description");
+        result.IsEnvironmentallyEnabled.ReturnsForAnyArgs(isEnvironmentallyEnabled);
+        result.RunnerSwitch.Returns(runnerSwitch);
+        var dualSink = MessageSinkAdapter.Wrap(messageSink ?? Substitute.For<IMessageSinkWithTypes, InterfaceProxy<IMessageSinkWithTypes>>());
+        result.CreateMessageHandler(null).ReturnsForAnyArgs(dualSink);
+        return result;
+    }
 
     public static ITest Test(ITestCase? testCase, string? displayName)
     {

--- a/test/FlakyTest.XUnit.Tests/XUnit/README.md
+++ b/test/FlakyTest.XUnit.Tests/XUnit/README.md
@@ -1,0 +1,6 @@
+https://github.com/xunit/xunit/discussions/2656#discussioncomment-4809326
+
+Code contained within this namespace is taken directly from the Xunit repo, 
+since I couldn't at a glance find if it was included as a part of any packages.
+
+Will remove this code eventually if I find it in the exposed Xunit packages.


### PR DESCRIPTION
# Description

* Adds more testing around the actual test cases. 
* Overall disposition to a test case (flaky or maybe fixed) - should be additive, not breaking to current API AFAIK
  * Not started
  * Running
  * Cancelled
  * Fail
  * Success
* Might be able to pull out some of the copied `NSubstitute` mocks introduced depending on the answer from https://github.com/xunit/xunit/discussions/2656

## Type of Change

Use an `x` in between the `[ ]` for each line applicable to the type of change for this PR

- [ ] Bug fix
- [x] New Feature
- [x] Documentation
- [x] Code improvement
- [ ] Breaking change - if a public API changes, or any change that **_DOES_** or **_MAY_** require a major revision to the NuGet package version due to [semver](https://semver.org/).
- [x] Unit tests
- [x] Code samples
- [ ] Added your repository URL to the readme because you make use of this super cool package! ;)
- [ ] Other

## Describe testing that was performed for your change

Added some additional hooks to help with testing, and the overall disposition of the test *could* be useful? IDK

## Checklist

- [x] Read the https://github.com/Kritner-Blogs/FlakyTest.XUnit/blob/main/CONTRIBUTING.md
- [x] Ran unit tests and ensured they passed
- [x] Added unit tests where applicable
- [ ] Referenced an issue where applicable
- [x] Ran `dotnet-format` locally
